### PR TITLE
add if statement for just j0 kernel

### DIFF
--- a/empymod/transform.py
+++ b/empymod/transform.py
@@ -902,7 +902,7 @@ def dlf(signal, points, out_pts, filt, pts_per_dec, kind=None, factAng=None,
 
             # for just j0 kernel
             if k_used[0] and ~k_used[2]:  # Only if kernel contains info
-                out_signal += np.dot(inp_PJ0 + filt.j0)
+                out_signal += np.dot(inp_PJ0, filt.j0)
 
             elif k_used[0] or k_used[2]:  # Only if kernel contains info
                 out_signal += np.dot(inp_PJ0 + factAng[:, np.newaxis]*inp_PJ0b,

--- a/empymod/transform.py
+++ b/empymod/transform.py
@@ -900,7 +900,11 @@ def dlf(signal, points, out_pts, filt, pts_per_dec, kind=None, factAng=None,
             else:
                 out_signal = alt_pre[:]
 
-            if k_used[0] or k_used[2]:  # Only if kernel contains info
+            # for just j0 kernel
+            if k_used[0] and ~k_used[2]:  # Only if kernel contains info
+                out_signal += np.dot(inp_PJ0 + filt.j0)
+
+            elif k_used[0] or k_used[2]:  # Only if kernel contains info
                 out_signal += np.dot(inp_PJ0 + factAng[:, np.newaxis]*inp_PJ0b,
                                      filt.j0)
 


### PR DESCRIPTION
can we add this line?
For `VMD` in simpegEM1D, I only need `j0` kernel, not `j0b`