### PR TITLE
Fix ``pts_per_dec``.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 #########
 
+*latest*
+--------
+
+- ``pts_per_dec`` are now floats, not integers, which gives more flexibility.
+- Bugfix: ``pts_per_dec`` for DLF was actually points per ``e``, not per
+  decade, as the natural logarithm was used.
+- New ``Versions``-class; improvement over the ``versions``-function, as it
+  automatically detects if it can print html or not.
+
 v1.8.1 - *2018-11-20*
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Changelog
   decade, as the natural logarithm was used.
 - New ``Versions``-class; improvement over the ``versions``-function, as it
   automatically detects if it can print html or not.
+- Maintenance: Update ``np.load`` in tests with ``allow_pickle=True`` for
+  changes in numpy v1.16.3.
 
 v1.8.1 - *2018-11-20*
 ---------------------

--- a/empymod/__init__.py
+++ b/empymod/__init__.py
@@ -828,4 +828,4 @@ __all__ = ['model', 'utils', 'filters', 'transform', 'kernel', 'scripts',
            'DigitalFilter']
 
 # Version
-__version__ = '1.8.2.dev0'
+__version__ = '1.8.2.branch_ptsperdec'

--- a/empymod/__init__.py
+++ b/empymod/__init__.py
@@ -828,4 +828,4 @@ __all__ = ['model', 'utils', 'filters', 'transform', 'kernel', 'scripts',
            'DigitalFilter']
 
 # Version
-__version__ = '1.8.2.branch_ptsperdec'
+__version__ = '1.8.2.dev0'

--- a/empymod/transform.py
+++ b/empymod/transform.py
@@ -1167,20 +1167,18 @@ def get_spline_values(filt, inp, nr_per_dec=None):
     outmax = filt.base[-1]/inp.min()
     outmin = filt.base[0]/inp.max()
 
-    # Define number of out-values, depending on pts_per_dec
-    def nr_of_out(outmax, outmin, pts_per_dec):
-        r"""Number of out-values."""
-        return int(np.ceil(np.log(outmax/outmin)*pts_per_dec) + 1)
-
-    # Get pts_per_dec
+    # Get pts_per_dec and define number of out-values, depending on pts_per_dec
     if nr_per_dec < 0:  # Lagged Convolution DLF
         pts_per_dec = 1/np.log(filt.factor)
+
+        # Calculate number of output values
+        nout = int(np.ceil(np.log(outmax/outmin)*pts_per_dec) + 1)
 
     else:  # Splined DLF
         pts_per_dec = nr_per_dec
 
-    # Calculate number of output values
-    nout = nr_of_out(outmax, outmin, pts_per_dec)
+        # Calculate number of output values
+        nout = int(np.ceil(np.log10(outmax/outmin)*pts_per_dec) + 1)
 
     # Min-nout check, becaus the cubic InterpolatedUnivariateSpline needs at
     # least 4 points.

--- a/empymod/transform.py
+++ b/empymod/transform.py
@@ -1197,16 +1197,19 @@ def get_spline_values(filt, inp, nr_per_dec=None):
         if nout < 4:
             nout = 4
 
-    # Calculate output values
-    out = np.exp(np.arange(np.log(outmin), np.log(outmin) + nout/pts_per_dec,
-                           1/pts_per_dec))
-
     if nr_per_dec < 0:
+        # Calculate output values
+        out = np.exp(np.arange(np.log(outmin), np.log(outmin) +
+                               nout/pts_per_dec, 1/pts_per_dec))
         # If lagged convolution is used, we calculate the new input values, as
         # spline is carried out in the input domain.
         new_inp = inp.max()*np.exp(-np.arange(nout - filt.base.size + 1) /
                                    pts_per_dec)
     else:
+        # Calculate output values
+        out = 10**np.arange(np.log10(outmin), np.log10(outmin) +
+                            nout/pts_per_dec, 1/pts_per_dec)
+
         # If spline is used, interpolation is carried out in output domain and
         # we calculate the intermediate values.
         new_inp = filt.base/inp[:, None]

--- a/empymod/utils.py
+++ b/empymod/utils.py
@@ -480,7 +480,7 @@ def check_hankel(ht, htarg, verb):
 
         # Check pts_per_dec; defaults to 0
         try:
-            pts_per_dec = _check_var(htarg['pts_per_dec'], int, 0,
+            pts_per_dec = _check_var(htarg['pts_per_dec'], float, 0,
                                      'fht: pts_per_dec', ())
         except VariableCatch:
             pts_per_dec = 0
@@ -534,7 +534,7 @@ def check_hankel(ht, htarg, verb):
 
         # pts_per_dec : 0  # No spline
         try:
-            pts_per_dec = _check_var(htarg['pts_per_dec'], int, 0,
+            pts_per_dec = _check_var(htarg['pts_per_dec'], float, 0,
                                      'qwe: pts_per_dec', ())
             pts_per_dec = _check_min(pts_per_dec, 0, 'pts_per_dec', '', verb)
         except VariableCatch:
@@ -626,7 +626,7 @@ def check_hankel(ht, htarg, verb):
 
         # pts_per_dec : 40
         try:
-            pts_per_dec = _check_var(htarg['pts_per_dec'], int, 0,
+            pts_per_dec = _check_var(htarg['pts_per_dec'], float, 0,
                                      'quad: pts_per_dec', ())
             pts_per_dec = _check_min(pts_per_dec, 1, 'pts_per_dec', '', verb)
         except VariableCatch:
@@ -976,7 +976,7 @@ def check_time(time, signal, ft, ftarg, verb):
 
         # Check pts_per_dec; defaults to -1
         try:
-            pts_per_dec = _check_var(ftarg['pts_per_dec'], int, 0,
+            pts_per_dec = _check_var(ftarg['pts_per_dec'], float, 0,
                                      ft + 'pts_per_dec', ())
         except VariableCatch:
             pts_per_dec = -1
@@ -1047,7 +1047,7 @@ def check_time(time, signal, ft, ftarg, verb):
             maxint = np.array(200, dtype=int)
 
         try:  # pts_per_dec
-            pts_per_dec = _check_var(ftarg['pts_per_dec'], int, 0,
+            pts_per_dec = _check_var(ftarg['pts_per_dec'], float, 0,
                                      'qwe: pts_per_dec', ())
             pts_per_dec = _check_min(pts_per_dec, 1, 'pts_per_dec', '', verb)
         except VariableCatch:
@@ -1112,7 +1112,7 @@ def check_time(time, signal, ft, ftarg, verb):
                                     'tcalc', 'dlnr', 'kr', 'rk'])
 
         try:  # pts_per_dec
-            pts_per_dec = _check_var(ftarg['pts_per_dec'], int, 0,
+            pts_per_dec = _check_var(ftarg['pts_per_dec'], float, 0,
                                      'fftlog: pts_per_dec', ())
             pts_per_dec = _check_min(pts_per_dec, 1, 'pts_per_dec', '', verb)
         except VariableCatch:
@@ -1186,7 +1186,7 @@ def check_time(time, signal, ft, ftarg, verb):
 
         # Check pts_per_dec; defaults to None
         try:
-            pts_per_dec = _check_var(ftarg['pts_per_dec'], int, 0,
+            pts_per_dec = _check_var(ftarg['pts_per_dec'], float, 0,
                                      'fft: pts_per_dec', ())
             pts_per_dec = _check_min(pts_per_dec, 1, 'pts_per_dec', '', verb)
         except VariableCatch:

--- a/empymod/utils.py
+++ b/empymod/utils.py
@@ -1883,6 +1883,8 @@ def _check_shape(var, name, shape, shape2=None):
 
 def _check_var(var, dtype, ndmin, name, shape=None, shape2=None):
     r"""Return variable as array of dtype, ndmin; shape-checked."""
+    if var is None:
+        raise ValueError
     var = np.array(var, dtype=dtype, copy=True, ndmin=ndmin)
     if shape:
         _check_shape(var, name, shape, shape2)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -468,14 +468,14 @@ def test_dlf():                                                       # 10. dlf
 
         # # # 3. Spline; Multi angle # # #
 
-        lambd, _ = transform.get_spline_values(fhtfilt, off, 10)
+        lambd, _ = transform.get_spline_values(fhtfilt, off, 30)
         # fht calculation
         PJ3 = kernel.wavenumber(zsrc, zrec, lsrc, lrec, depth, etaH, etaV,
                                 zetaH, zetaV, lambd, ab, xdirect, msrc, mrec,
                                 use_ne_eval)
 
         # dlf calculation
-        fEM3 = transform.dlf(PJ3, lambd, off, fhtfilt, 10, factAng=factAng,
+        fEM3 = transform.dlf(PJ3, lambd, off, fhtfilt, 30, factAng=factAng,
                              ab=ab)
 
         # Compare

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -496,10 +496,10 @@ def test_check_time(capsys):
 
     # ['', 0]  :: dict, deprecated
     _, f, _, ftarg = utils.check_time(time, 0, 'sin', {'pts_per_dec': None}, 0)
-#     assert ftarg[1] == -1
-#     assert_allclose(f[:9], f1)
-#     assert_allclose(f[-9:], f2)
-#     assert_allclose(f.size, 204)
+    assert ftarg[1] == -1
+    assert_allclose(f[:9], f1)
+    assert_allclose(f[-9:], f2)
+    assert_allclose(f.size, 204)
 
     # # QWE # #
     # verbose

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -247,7 +247,7 @@ def test_check_hankel(capsys):
     # [filter str, pts_per_dec]
     _, htarg = utils.check_hankel('fht', ['key_201_2009', 20], 4)
     out, _ = capsys.readouterr()
-    assert "     > DLF type    :  Splined, 20 pts/dec" in out
+    assert "     > DLF type    :  Splined, 20.0 pts/dec" in out
     assert htarg[0].name == filters.key_201_2009().name
     assert htarg[1] == 20
 
@@ -467,7 +467,7 @@ def test_check_time(capsys):
     assert ftarg[1] == 30
     assert ftarg[2] == 'sin'
     out, _ = capsys.readouterr()
-    assert "     > DLF type    :  Splined, 30 pts/dec" in out
+    assert "     > DLF type    :  Splined, 30.0 pts/dec" in out
 
     # [filter str, pts_per_dec]
     _, _, _, ftarg = utils.check_time(time, 0, 'cos',
@@ -496,10 +496,10 @@ def test_check_time(capsys):
 
     # ['', 0]  :: dict, deprecated
     _, f, _, ftarg = utils.check_time(time, 0, 'sin', {'pts_per_dec': None}, 0)
-    assert ftarg[1] == -1
-    assert_allclose(f[:9], f1)
-    assert_allclose(f[-9:], f2)
-    assert_allclose(f.size, 204)
+#     assert ftarg[1] == -1
+#     assert_allclose(f[:9], f1)
+#     assert_allclose(f[-9:], f2)
+#     assert_allclose(f.size, 204)
 
     # # QWE # #
     # verbose


### PR DESCRIPTION
In ``empymod.transform.get_spline_values``, ``log`` is used instead of ``log10``. So ``pts_per_dec`` is actually not per decade, but per ``e`` in the DLF.

Fixes #34.