### PR TITLE
Other filter coefficiens and inverse of theoretical pairs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,14 @@ Changelog
 
 *latest*
 --------
+
 - Laplace-domain calculation: By providing a negative ``freq``-value, the
   calculation is carried out in the real Laplace domain ``s = freq`` instead of
   the complex frequency domain ``s = 2i*pi*freq``.
+- ``DigitalFilter`` now takes an argument to have other coefficients than
+  ``j0``, ``j1``, ``sin``, and ``cos``.
+- The provided sine and cosine transform pairs in ``fdesign`` can now be
+  asked to return the inverse pair (time to frequency).
 
 
 v1.8.3 - *2019-07-05*

--- a/empymod/filters.py
+++ b/empymod/filters.py
@@ -65,24 +65,41 @@ __all__ = ['DigitalFilter', 'kong_61_2007', 'kong_241_2007', 'key_101_2009',
 # 0. Filter Class and saving/loading routines
 
 class DigitalFilter:
-    r"""Simple Class for Digital Linear Filters."""
+    r"""Simple Class for Digital Linear Filters.
 
-    # Possible filter names; including on top of the normal ones:
-    # - 'lap'   : Laplace to time           : x-s => x-t
-    # - 's2fr'  : Laplace to frequency      : x-s => x-f.real
-    # - 's2fi'  : Laplace to frequency      : x-s => x-f.imag
-    # - 'cos_i' : Inverse time to frequency : x-t => x-f.real
-    # - 'sin_i' : Inverse time to frequency : x-t => x-f.imag
-    fnames = ['j0', 'j1', 'sin', 'cos',
-              'lap', 's2fr', 's2fi', 'sin_i', 'cos_i']
 
-    def __init__(self, name, savename=None):
+    Parameters
+    ----------
+    name : str
+        Name of the DFL.
+
+    savename = str
+        Name with which the filter is saved. If None (default) it is set to the
+        same value as ``name``.
+
+    filter_coeff = list of str
+        By default, the following filter coefficients are checked:
+
+            ``filter_coeff = ['j0', 'j1', 'sin', 'cos']``
+
+        This accounts for the standard Hankel and Fourier DLF in CSEM
+        modelling. However, other coefficient names can be provided via this
+        parameter (in list format).
+
+    """
+
+    def __init__(self, name, savename=None, filter_coeff=None):
         r"""Add filter name."""
         self.name = name
         if savename is None:
             self.savename = name
         else:
             self.savename = savename
+
+        if filter_coeff is None:
+            self.filter_coeff = ['j0', 'j1', 'sin', 'cos']
+        else:
+            self.filter_coeff = filter_coeff
 
     def tofile(self, path='filters'):
         r"""Save filter values to ascii-files.
@@ -117,7 +134,7 @@ class DigitalFilter:
             self.base.tofile(f, sep="\n")
 
         # Save filter coefficients
-        for val in self.fnames:
+        for val in self.filter_coeff:
             if hasattr(self, val):
                 attrfile = os.path.join(path, name + '_' + val + '.txt')
                 with open(attrfile, 'w') as f:
@@ -157,7 +174,7 @@ class DigitalFilter:
             self.base = np.fromfile(f, sep="\n")
 
         # Get filter coefficients
-        for val in self.fnames:
+        for val in self.filter_coeff:
             attrfile = os.path.join(path, name + '_' + val + '.txt')
             if os.path.isfile(attrfile):
                 with open(attrfile, 'r') as f:

--- a/empymod/filters.py
+++ b/empymod/filters.py
@@ -66,6 +66,16 @@ __all__ = ['DigitalFilter', 'kong_61_2007', 'kong_241_2007', 'key_101_2009',
 
 class DigitalFilter:
     r"""Simple Class for Digital Linear Filters."""
+
+    # Possible filter names; including on top of the normal ones:
+    # - 'lap'   : Laplace to time           : x-s => x-t
+    # - 's2fr'  : Laplace to frequency      : x-s => x-f.real
+    # - 's2fi'  : Laplace to frequency      : x-s => x-f.imag
+    # - 'cos_i' : Inverse time to frequency : x-t => x-f.real
+    # - 'sin_i' : Inverse time to frequency : x-t => x-f.imag
+    fnames = ['j0', 'j1', 'sin', 'cos',
+              'lap', 's2fr', 's2fi', 'sin_i', 'cos_i']
+
     def __init__(self, name, savename=None):
         r"""Add filter name."""
         self.name = name
@@ -107,7 +117,7 @@ class DigitalFilter:
             self.base.tofile(f, sep="\n")
 
         # Save filter coefficients
-        for val in ['j0', 'j1', 'sin', 'cos']:
+        for val in self.fnames:
             if hasattr(self, val):
                 attrfile = os.path.join(path, name + '_' + val + '.txt')
                 with open(attrfile, 'w') as f:
@@ -147,7 +157,7 @@ class DigitalFilter:
             self.base = np.fromfile(f, sep="\n")
 
         # Get filter coefficients
-        for val in ['j0', 'j1', 'sin', 'cos']:
+        for val in self.fnames:
             attrfile = os.path.join(path, name + '_' + val + '.txt')
             if os.path.isfile(attrfile):
                 with open(attrfile, 'r') as f:

--- a/empymod/scripts/fdesign.py
+++ b/empymod/scripts/fdesign.py
@@ -47,11 +47,12 @@ in the following way:
 
        return fdesign.Ghosh(name, lhs, rhs)
 
-Here, ``name`` must be one of ``j0``, ``j1``, ``sin``, or ``cos``, depending
-what type of transform pair it is. Additional variables are provided with
-``var``. The evaluation points of the ``lhs`` are denoted by ``l``, and the
-evaluation points of the ``rhs`` are denoted as ``r``. As an example here the
-implemented transform pair ``j0_1``
+Here, ``name`` must be one of ``j0``, ``j1``, ``sin``, ``cos``, ``lap``,
+``s2fr``, ``s2fi``, ``sin_i``, or ``cos_i``, depending what type of transform
+pair it is. Additional variables are provided with ``var``. The evaluation
+points of the ``lhs`` are denoted by ``l``, and the evaluation points of the
+``rhs`` are denoted as ``r``. As an example here the implemented transform pair
+``j0_1``
 
 .. code-block:: python
 
@@ -633,7 +634,10 @@ def plot_result(filt, full, prntres=True):
     if spacing.size > 1 or shift.size > 1:
         plt.subplot(122)
     plt.title('Filter values of best filter')
-    for attr in ['j0', 'j1', 'sin', 'cos']:
+    fnames = ['j0', 'j1', 'sin', 'cos',
+              'lap', 's2fr', 's2fi', 'sin_i', 'cos_i']
+
+    for attr in fnames:
         if hasattr(filt, attr):
             plt.plot(np.log10(filt.base),
                      np.log10(np.abs(getattr(filt, attr))), '.-', lw=.5,
@@ -755,12 +759,14 @@ def _plot_transform_pairs(fCI, r, k, axes, tit):
         else:
             plt.loglog(r, np.abs(f.rhs(r)), lw=2, label=f.name)
 
-    # Transform with Key
+    # Transform with Key :: TODO Adjust for additional transforms
     for f in fCI:
-        if f.name[1] in ['0', '1', '2']:
+        if f.name[1] in ['0', '1', '2'] and f.name[0] != 's':
             filt = j0j1filt()
-        else:
+        elif f.name in ['cos', 'sin']:
             filt = sincosfilt()
+        else:  # TODO Adjust for additional transforms
+            break
         kk = filt.base/r[:, None]
         if f.name == 'j2':
             lhs = f.lhs(kk)
@@ -1030,7 +1036,7 @@ def j1_5(f=1, rho=0.3, z=50):
 
 # # 3.c Fourier sine transform pairs
 
-def sin_1(a=1):
+def sin_1(a=1, inverse=False):
     r"""Fourier sine transform pair sin_1 ([Ande75]_)."""
 
     def lhs(x):
@@ -1039,10 +1045,13 @@ def sin_1(a=1):
     def rhs(b):
         return np.sqrt(np.pi)*b*np.exp(-b**2/(4*a**2))/(4*a**3)
 
-    return Ghosh('sin', lhs, rhs)
+    if inverse:
+        return Ghosh('sin_i', rhs, lhs)
+    else:
+        return Ghosh('sin', lhs, rhs)
 
 
-def sin_2(a=1):
+def sin_2(a=1, inverse=False):
     r"""Fourier sine transform pair sin_2 ([Ande75]_)."""
 
     def lhs(x):
@@ -1051,10 +1060,13 @@ def sin_2(a=1):
     def rhs(b):
         return b/(b**2 + a**2)
 
-    return Ghosh('sin', lhs, rhs)
+    if inverse:
+        return Ghosh('sin_i', rhs, lhs)
+    else:
+        return Ghosh('sin', lhs, rhs)
 
 
-def sin_3(a=1):
+def sin_3(a=1, inverse=False):
     r"""Fourier sine transform pair sin_3 ([Ande75]_)."""
 
     def lhs(x):
@@ -1063,12 +1075,15 @@ def sin_3(a=1):
     def rhs(b):
         return np.pi*np.exp(-a*b)/2
 
-    return Ghosh('sin', lhs, rhs)
+    if inverse:
+        return Ghosh('sin_i', rhs, lhs)
+    else:
+        return Ghosh('sin', lhs, rhs)
 
 
 # # 3.d Fourier cosine transform pairs
 
-def cos_1(a=1):
+def cos_1(a=1, inverse=False):
     r"""Fourier cosine transform pair cos_1 ([Ande75]_)."""
 
     def lhs(x):
@@ -1077,10 +1092,13 @@ def cos_1(a=1):
     def rhs(b):
         return np.sqrt(np.pi)*np.exp(-b**2/(4*a**2))/(2*a)
 
-    return Ghosh('cos', lhs, rhs)
+    if inverse:
+        return Ghosh('cos_i', rhs, lhs)
+    else:
+        return Ghosh('cos', lhs, rhs)
 
 
-def cos_2(a=1):
+def cos_2(a=1, inverse=False):
     r"""Fourier cosine transform pair cos_2 ([Ande75]_)."""
 
     def lhs(x):
@@ -1089,10 +1107,13 @@ def cos_2(a=1):
     def rhs(b):
         return a/(b**2 + a**2)
 
-    return Ghosh('cos', lhs, rhs)
+    if inverse:
+        return Ghosh('cos_i', rhs, lhs)
+    else:
+        return Ghosh('cos', lhs, rhs)
 
 
-def cos_3(a=1):
+def cos_3(a=1, inverse=False):
     r"""Fourier cosine transform pair cos_3 ([Ande75]_)."""
 
     def lhs(x):
@@ -1101,7 +1122,10 @@ def cos_3(a=1):
     def rhs(b):
         return np.pi*np.exp(-a*b)/(2*a)
 
-    return Ghosh('cos', lhs, rhs)
+    if inverse:
+        return Ghosh('cos_i', rhs, lhs)
+    else:
+        return Ghosh('cos', lhs, rhs)
 
 
 # # 3.e Modeller

--- a/empymod/scripts/fdesign.py
+++ b/empymod/scripts/fdesign.py
@@ -47,12 +47,11 @@ in the following way:
 
        return fdesign.Ghosh(name, lhs, rhs)
 
-Here, ``name`` must be one of ``j0``, ``j1``, ``sin``, ``cos``, ``lap``,
-``s2fr``, ``s2fi``, ``sin_i``, or ``cos_i``, depending what type of transform
-pair it is. Additional variables are provided with ``var``. The evaluation
-points of the ``lhs`` are denoted by ``l``, and the evaluation points of the
-``rhs`` are denoted as ``r``. As an example here the implemented transform pair
-``j0_1``
+Here, ``name`` must be one of ``j0``, ``j1``, ``sin``, or ``cos``, depending
+what type of transform pair it is. Additional variables are provided with
+``var``. The evaluation points of the ``lhs`` are denoted by ``l``, and the
+evaluation points of the ``rhs`` are denoted as ``r``. As an example here the
+implemented transform pair ``j0_1``
 
 .. code-block:: python
 
@@ -634,10 +633,7 @@ def plot_result(filt, full, prntres=True):
     if spacing.size > 1 or shift.size > 1:
         plt.subplot(122)
     plt.title('Filter values of best filter')
-    fnames = ['j0', 'j1', 'sin', 'cos',
-              'lap', 's2fr', 's2fi', 'sin_i', 'cos_i']
-
-    for attr in fnames:
+    for attr in ['j0', 'j1', 'sin', 'cos']:
         if hasattr(filt, attr):
             plt.plot(np.log10(filt.base),
                      np.log10(np.abs(getattr(filt, attr))), '.-', lw=.5,
@@ -759,14 +755,12 @@ def _plot_transform_pairs(fCI, r, k, axes, tit):
         else:
             plt.loglog(r, np.abs(f.rhs(r)), lw=2, label=f.name)
 
-    # Transform with Key :: TODO Adjust for additional transforms
+    # Transform with Key
     for f in fCI:
-        if f.name[1] in ['0', '1', '2'] and f.name[0] != 's':
+        if f.name[1] in ['0', '1', '2']:
             filt = j0j1filt()
-        elif f.name in ['cos', 'sin']:
+        else:
             filt = sincosfilt()
-        else:  # TODO Adjust for additional transforms
-            break
         kk = filt.base/r[:, None]
         if f.name == 'j2':
             lhs = f.lhs(kk)
@@ -1046,7 +1040,7 @@ def sin_1(a=1, inverse=False):
         return np.sqrt(np.pi)*b*np.exp(-b**2/(4*a**2))/(4*a**3)
 
     if inverse:
-        return Ghosh('sin_i', rhs, lhs)
+        return Ghosh('sin', rhs, lhs)
     else:
         return Ghosh('sin', lhs, rhs)
 
@@ -1061,7 +1055,7 @@ def sin_2(a=1, inverse=False):
         return b/(b**2 + a**2)
 
     if inverse:
-        return Ghosh('sin_i', rhs, lhs)
+        return Ghosh('sin', rhs, lhs)
     else:
         return Ghosh('sin', lhs, rhs)
 
@@ -1076,7 +1070,7 @@ def sin_3(a=1, inverse=False):
         return np.pi*np.exp(-a*b)/2
 
     if inverse:
-        return Ghosh('sin_i', rhs, lhs)
+        return Ghosh('sin', rhs, lhs)
     else:
         return Ghosh('sin', lhs, rhs)
 
@@ -1093,7 +1087,7 @@ def cos_1(a=1, inverse=False):
         return np.sqrt(np.pi)*np.exp(-b**2/(4*a**2))/(2*a)
 
     if inverse:
-        return Ghosh('cos_i', rhs, lhs)
+        return Ghosh('cos', rhs, lhs)
     else:
         return Ghosh('cos', lhs, rhs)
 
@@ -1108,7 +1102,7 @@ def cos_2(a=1, inverse=False):
         return a/(b**2 + a**2)
 
     if inverse:
-        return Ghosh('cos_i', rhs, lhs)
+        return Ghosh('cos', rhs, lhs)
     else:
         return Ghosh('cos', lhs, rhs)
 
@@ -1123,7 +1117,7 @@ def cos_3(a=1, inverse=False):
         return np.pi*np.exp(-a*b)/(2*a)
 
     if inverse:
-        return Ghosh('cos_i', rhs, lhs)
+        return Ghosh('cos', rhs, lhs)
     else:
         return Ghosh('cos', lhs, rhs)
 

--- a/tests/test_fdesign.py
+++ b/tests/test_fdesign.py
@@ -345,6 +345,29 @@ def test_sincos():
 
         assert_allclose(rhs2a, rhs2c, rtol=1e-3)
 
+    # Check inverse
+    for sc in ['1', '2', '3']:
+        if sc == '1':
+            r = np.logspace(0, 0.7, 100)
+        else:
+            r = np.logspace(0, 1, 100)
+
+        k = filt.base/r[:, None]
+        tps = getattr(fdesign, 'sin_'+sc)()
+        tpc = getattr(fdesign, 'cos_'+sc)()
+        tps_i = getattr(fdesign, 'sin_'+sc)(inverse=True)
+        tpc_i = getattr(fdesign, 'cos_'+sc)(inverse=True)
+
+        rhs1a = tps.rhs(r)
+        rhs1c = tps_i.lhs(r)
+
+        assert_allclose(rhs1a, rhs1c)
+
+        rhs2a = tpc.rhs(r)
+        rhs2c = tpc_i.lhs(r)
+
+        assert_allclose(rhs2a, rhs2c)
+
 
 def test_empy_hankel():
 

--- a/tests/test_fdesign.py
+++ b/tests/test_fdesign.py
@@ -94,9 +94,11 @@ def test_save_load_filter(tmpdir):
     dat1 = DATA['case1'][()]
     dat1[1].name = 'one'
     dat1[1].savename = 'one'
+    dat1[1].filter_coeff = ['j0', 'j1', 'sin', 'cos']
     dat2 = DATA['case2'][()]
     dat2[1].name = 'two'
     dat2[1].savename = 'two'
+    dat2[1].filter_coeff = ['j0', 'j1', 'sin', 'cos']
     fdesign.save_filter('one', dat1[1], dat1[2], path=tmpdir)
     fdesign.save_filter('one.gz', dat1[1], dat1[2], path=tmpdir)  # Check gz
     fdesign.save_filter('two', dat2[1], path=tmpdir)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -11,10 +11,13 @@ def test_digitalfilter():                                   # 1.a DigitalFilter
     # Assure a DigitalFilter has attribute 'name'.
     out1 = filters.DigitalFilter('test')
     out2 = filters.DigitalFilter('test', 'savenametest')
+    out3 = filters.DigitalFilter('test', filter_coeff=['abc', ])
     assert out1.name == 'test'
     assert out1.savename == out1.name
     assert out1.name == out2.name
+    assert out1.filter_coeff == ['j0', 'j1', 'sin', 'cos']
     assert out2.savename == 'savenametest'
+    assert out3.filter_coeff == ['abc', ]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1077,5 +1077,8 @@ def test_versions_backwards():
         out2 = utils.Versions()
         out3 = utils.versions()
 
-        assert out1.__repr__() == out2.__repr__()
-        assert out1.__repr__() == out3.__repr__()
+        # Exclude minutes and seconds, to avoid stupid failures.
+        assert out1.__repr__()[:336] == out2.__repr__()[:336]
+        assert out1.__repr__()[341:] == out2.__repr__()[341:]
+        assert out1.__repr__()[:336] == out3.__repr__()[:336]
+        assert out1.__repr__()[341:] == out3.__repr__()[341:]


### PR DESCRIPTION
- `DigitalFilter` now takes an argument to have other coefficients than `j0`, `j1`, `sin`, and `cos`.
- The provided sine and cosine transform pairs in `fdesign` can now be asked to return the inverse pair (time to frequency).