### PR TITLE
Open-up fdesign for any transform pair

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,21 +2,29 @@ Changelog
 #########
 
 
-*latest*
---------
+*latest* : Laplace
+------------------
 
 - Laplace-domain calculation: By providing a negative ``freq``-value, the
   calculation is carried out in the real Laplace domain ``s = freq`` instead of
   the complex frequency domain ``s = 2i*pi*freq``.
-- ``DigitalFilter`` now takes an argument to have other coefficients than
-  ``j0``, ``j1``, ``sin``, and ``cos``.
-- The provided sine and cosine transform pairs in ``fdesign`` can now be
-  asked to return the inverse pair (time to frequency).
+- More flexible filters and filter design:
+
+  - ``DigitalFilter`` now takes an argument (list of strings) to have other
+    coefficients than ``j0``, ``j1``, ``sin``, and ``cos``.
+  - ``fdesign`` can now be used with any name as attribute you want to describe
+    the transform pair (until now it had to be either ``j0``, ``j1``, ``j2``,
+    ``sin``, or ``cos``).
+  - The provided sine and cosine transform pairs in ``fdesign`` can now be
+    asked to return the inverse pair (time to frequency).
+
 - Other tiny improvements and bug fixes.
 
 
-v1.8.3 - *2019-07-05*
----------------------
+v1.8.3 : Scooby
+---------------
+
+**2019-07-05**
 
 - Use ``scooby`` for ``Versions`` (printinfo), change name to ``Report``.
 - DOC: Correct return statement if ``mrec=True``.
@@ -25,8 +33,10 @@ v1.8.3 - *2019-07-05*
   SciPy 0.19.0.
 
 
-v1.8.2 - *2019-04-26*
----------------------
+v1.8.2 : pts_per_dec for DLF are now floats
+-------------------------------------------
+
+**2019-04-26**
 
 - ``pts_per_dec`` are now floats, not integers, which gives more flexibility.
 - Bugfix: ``pts_per_dec`` for DLF was actually points per ``e``, not per
@@ -49,8 +59,10 @@ v1.8.2 - *2019-04-26*
   CREDITS.rst, where it belongs.
 
 
-v1.8.1 - *2018-11-20*
----------------------
+v1.8.1 : Version of Filter-article and CSEM-book
+------------------------------------------------
+
+**2018-11-20**
 
 - Many little improvements in the documentation.
 - Some code improvements through the use of codacy.
@@ -60,8 +72,10 @@ v1.8.1 - *2018-11-20*
   <https://github.com/empymod/csem-ziolkowski-and-slob>`_.
 
 
-v1.8.0 - *2018-10-26*
----------------------
+v1.8.0 : Hook for Cole-Cole IP and similar
+------------------------------------------
+
+**2018-10-26**
 
 - ``model.bipole``, ``model.dipole``, and ``model.analytical`` have now a hook
   which users can exploit to insert their own calculation of ``etaH``,
@@ -92,8 +106,10 @@ for the user-facing routines in ``model``:
   Move there in version 2.0.
 
 
-v1.7.3 - *2018-07-16*
----------------------
+v1.7.3 : Speed improvements following benchmarks
+------------------------------------------------
+
+**2018-07-16**
 
 - Small improvements related to speed as a result of the benchmarks introduced
   in v1.7.2:
@@ -113,8 +129,10 @@ v1.7.3 - *2018-07-16*
     ``factAng``; ``log10``/``log``; re-arranging).
 
 
-v1.7.2 - *2018-07-07*
----------------------
+v1.7.2 : Benchmarked with asv
+-----------------------------
+
+**2018-07-07**
 
 - Benchmarks: ``empymod`` has now a benchmark suite, see `empymod/asv
   <https://github.com/empymod/asv>`_.
@@ -130,8 +148,10 @@ v1.7.2 - *2018-07-07*
     and ``transform.qwe``.
 
 
-v1.7.1 - *2018-06-19*
----------------------
+v1.7.1 : Load/save filters in plain text
+----------------------------------------
+
+**2018-06-19**
 
 - New routines in ``empymod.filters.DigitalFilter``: Filters can now be saved
   to or loaded from pure ascii-files.
@@ -160,8 +180,10 @@ v1.7.1 - *2018-06-19*
 - Version of re-submission of the DLF article to geophysics.
 
 
-v1.7.0 - *2018-05-23*
----------------------
+v1.7.0 : Move empyscripts into empymod.scripts
+----------------------------------------------
+
+**2018-05-23**
 
 Merge ``empyscripts`` into ``empymod`` under ``empymod.scripts``.
 
@@ -183,8 +205,10 @@ Merge ``empyscripts`` into ``empymod`` under ``empymod.scripts``.
   ``empymod`` directly.
 
 
-v1.6.2 - *2018-05-21*
----------------------
+v1.6.2 : Speed improvements for QUAD/QWE
+----------------------------------------
+
+**2018-05-21**
 
 These changes should make calculations using ``QWE`` and ``QUAD`` for the
 Hankel transform for cases which do not require all kernels faster; sometimes
@@ -216,8 +240,10 @@ including for ``QWE`` and ``QUAD`` what was included for ``DLF`` in version
   - Simplify ``angle_factor``
 
 
-v1.6.1 - *2018-05-05*
----------------------
+v1.6.1 : Primary/secondary field
+--------------------------------
+
+**2018-05-05**
 
 Secondary field calculation.
 
@@ -235,8 +261,10 @@ Secondary field calculation.
   [`empymod#16 <https://github.com/empymod/empymod/issues/16>`_].
 
 
-v1.6.0 - *2018-05-01*
----------------------
+v1.6.0 : More DLF improvements
+------------------------------
+
+**2018-05-01**
 
 This release is not completely backwards compatible for the main modelling
 routines in ``empymod.model``, but almost. Read below to see which functions
@@ -284,8 +312,10 @@ are affected.
 - Bugfix in ``model.wavenumber`` for ``ab=[36, 63]`` (zeroes).
 
 
-v1.5.2 - *2018-04-25*
+v1.5.2 : Improved DLF
 ---------------------
+
+**2018-04-25**
 
 - DLF improvements:
 
@@ -301,8 +331,10 @@ v1.5.2 - *2018-04-25*
     ``pts_per_dec`` can now be shorter then the corresponding filter.
 
 
-v1.5.1 - *2018-02-24*
----------------------
+v1.5.1 : Improved docs
+----------------------
+
+**2018-02-24**
 
 - Documentation:
 
@@ -324,8 +356,10 @@ v1.5.1 - *2018-02-24*
     compatibility.
 
 
-v1.5.0 - *2018-01-02*
----------------------
+v1.5.0 : Hankel filter wer_201_2018
+-----------------------------------
+
+**2018-01-02**
 
 - Minimum parameter values can now be set and verified with
   ``utils.set_minimum`` and ``utils.get_minimum``.
@@ -341,8 +375,10 @@ v1.5.0 - *2018-01-02*
 - Version of manuscript submission to geophysics for the DLF article.
 
 
-v1.4.4 - *2017-09-18*
----------------------
+v1.4.4 : TE/TM split
+--------------------
+
+**2017-09-18**
 
 [This was meant to be 1.4.3, but due to a setup/pypi/anaconda-issue I had to
 push it to 1.4.4; so there isn't really a version 1.4.3.]
@@ -360,16 +396,20 @@ push it to 1.4.4; so there isn't really a version 1.4.3.]
 - Bug fixes
 
 
-v1.4.2 - *2017-06-04*
----------------------
+v1.4.2 : Final submission version of Geophysics paper
+-----------------------------------------------------
+
+**2017-06-04**
 
 - Bugfix: Fixed squeeze in ``model.analytical`` with ``solution='dsplit'``.
 
 - Version of final submission of manuscript to Geophysics.
 
 
-v1.4.1 - *2017-05-30*
----------------------
+v1.4.1 : Own organisation github.com/empymod
+--------------------------------------------
+
+**2017-05-30**
 
 [This was meant to be 1.4.0, but due to a setup/pypi/anaconda-issue I had to
 push it to 1.4.1; so there isn't really a version 1.4.0.]
@@ -403,8 +443,10 @@ push it to 1.4.1; so there isn't really a version 1.4.0.]
     only fullspace solution (all for the diffusive approximation).
 
 
-v1.3.0 - *2017-03-30*
----------------------
+v1.3.0 : New transforms QUAD (Hankel) and FFT (Fourier)
+-------------------------------------------------------
+
+**2017-03-30**
 
 - Add additional transforms and improve QWE:
 
@@ -434,8 +476,10 @@ v1.3.0 - *2017-03-30*
 - Bug fixes and documentation improvements
 
 
-v1.2.1 - *2017-03-11*
----------------------
+v1.2.1 : Installable via pip and conda
+--------------------------------------
+
+**2017-03-11**
 
 - Change default filter from ``key_401_2009`` to ``key_201_2009`` (because of
   warning regarding 401 pt filter in source code of ``DIPOLE1D``.)
@@ -445,8 +489,10 @@ v1.2.1 - *2017-03-11*
 - Bug fixes
 
 
-v1.2.0 - *2017-02-02*
----------------------
+v1.2.0 : Bipole
+---------------
+
+**2017-02-02**
 
 - New routine:
 
@@ -480,8 +526,10 @@ v1.2.0 - *2017-02-02*
 - Bug fixes
 
 
-v1.1.0 - *2016-12-22*
----------------------
+v1.1.0 : Include source bipole
+------------------------------
+
+**2016-12-22**
 
 - New routines:
 
@@ -505,7 +553,9 @@ v1.1.0 - *2016-12-22*
 - Bug fixes
 
 
-v1.0.0 - *2016-11-29*
----------------------
+v1.0.0 : Initial release
+------------------------
+
+**2016-11-29**
 
 - Initial release; state of manuscript submission to geophysics.

--- a/empymod/scripts/fdesign.py
+++ b/empymod/scripts/fdesign.py
@@ -755,12 +755,14 @@ def _plot_transform_pairs(fCI, r, k, axes, tit):
         else:
             plt.loglog(r, np.abs(f.rhs(r)), lw=2, label=f.name)
 
-    # Transform with Key
+    # Transform with Key in the case of Hankel or Fourier transform.
     for f in fCI:
-        if f.name[1] in ['0', '1', '2']:
+        if f.name[1] in ['0', '1', '2'] and f.name[0] == 'j':
             filt = j0j1filt()
-        else:
+        elif f.name in ['sin', 'cos']:
             filt = sincosfilt()
+        else:
+            break
         kk = filt.base/r[:, None]
         if f.name == 'j2':
             lhs = f.lhs(kk)

--- a/tests/test_fdesign.py
+++ b/tests/test_fdesign.py
@@ -117,7 +117,7 @@ def test_save_load_filter(tmpdir):
 
     filt = fdesign.load_filter('two', True, path=tmpdir)
     assert_allclose(filt.base, dat2[1].base)
-    filt = fdesign.load_filter('two', path=tmpdir)
+    filt = fdesign.load_filter('two', path=tmpdir, filter_coeff=['bla'])
     assert_allclose(filt.base, dat2[1].base)
 
 


### PR DESCRIPTION
Filter names (attributes) can now be anything, not just `j0`, `j1`, `j2`, `sin`, and `cos`, widen the application of `fdesign` to any transform pair.