### PR TITLE
Use `kwargs` for settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,10 +50,12 @@ This version will be backwards incompatible, and only support Python 3.6+.
 
 - Other changes:
 
-  - ``bipole`` and ``dipole`` now only have the following mandatory positional
-    arguments: ``src``, ``rec``, ``depth``, ``res``, and ``freqtime``, and the
-    optional positional keyword arguments ``signal`` and ``aniso``; all the
-    others are now within ``**kwargs``.
+  - All settings (``xdirect``, ``ht``, ``htarg``, ``ft``, ``ftarg``, ``loop``,
+    ``verb``) are now extracted from ``kwargs``. This makes it possible that
+    all ``model``-functions take the same keyword-arguments; warnings are
+    raised if a particular parameter is not used in this function, but it
+    doesn't fail (it fails, however, for unknown parameters). Pure positional
+    calls including those parameters will therefore not work any longer.
   - ``htarg`` and ``ftarg`` internally are now dictionaries, not lists.
   - Undo a change introduced in v1.8.0: ``get_dlf_points`` is calculated
     directly within ``transform.fht`` [`empymod#26

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,10 @@ This version will be backwards incompatible, and only support Python 3.6+.
 
 - Other changes:
 
+  - ``bipole`` and ``dipole`` now only have the following mandatory positional
+    arguments: ``src``, ``rec``, ``depth``, ``res``, and ``freqtime``, and the
+    optional positional keyword arguments ``signal`` and ``aniso``; all the
+    others are now within ``**kwargs``.
   - ``htarg`` and ``ftarg`` internally are now dictionaries, not lists.
   - Undo a change introduced in v1.8.0: ``get_dlf_points`` is calculated
     directly within ``transform.fht`` [`empymod#26

--- a/README.rst
+++ b/README.rst
@@ -128,8 +128,8 @@ or via ``pip``:
 
    pip install empymod
 
-Required are Python version 3.6 or higher and the modules ``numpy``, ``scipy``,
-and ``numba``. Consult the installation notes in the `manual
+Required are Python version 3.6 or higher and the modules ``NumPy``, ``SciPy``,
+and ``Numba``. Consult the installation notes in the `manual
 <https://empymod.readthedocs.io/en/stable/manual.html#installation>`_ for more
 information regarding installation and requirements.
 

--- a/empymod/model.py
+++ b/empymod/model.py
@@ -67,10 +67,7 @@ __all__ = ['bipole', 'dipole', 'loop', 'analytical', 'gpr', 'dipole_k', 'fem',
            'tem']
 
 
-def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None,
-           epermH=None, epermV=None, mpermH=None, mpermV=None, msrc=False,
-           srcpts=1, mrec=False, recpts=1, strength=0, xdirect=False,
-           ht='dlf', htarg=None, ft='dlf', ftarg=None, loop=None, verb=2):
+def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
     r"""Return EM fields due to arbitrary rotated, finite length EM dipoles.
 
     Calculate the electromagnetic frequency- or time-domain field due to
@@ -385,6 +382,27 @@ def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None,
 
     """
 
+    # Get kwargs.                           # => create a utils-fct for this
+    epermH = kwargs.pop('epermH', None)     #
+    epermV = kwargs.pop('epermV', None)     #
+    mpermH = kwargs.pop('mpermH', None)     #
+    mpermV = kwargs.pop('mpermV', None)     #
+    msrc = kwargs.pop('msrc', False)        #
+    mrec = kwargs.pop('mrec', False)        #
+    srcpts = kwargs.pop('srcpts', 1)        #
+    recpts = kwargs.pop('recpts', 1)        #
+    strength = kwargs.pop('strength', 0)    #
+    xdirect = kwargs.pop('xdirect', False)  #
+    ht = kwargs.pop('ht', 'dlf')            #
+    htarg = kwargs.pop('htarg', None)       #
+    ft = kwargs.pop('ft', 'dlf')            #
+    ftarg = kwargs.pop('ftarg', None)       #
+    loop = kwargs.pop('loop', None)         #
+    verb = kwargs.pop('verb', 2)            #
+    # Ensure no kwargs left.                #
+    if kwargs:                              #
+        print(f"WAAAAAAAAAAA LEFT **kwargs: {kwargs}")
+
     # === 1.  LET'S START ============
     t0 = printstartfinish(verb)
 
@@ -558,9 +576,7 @@ def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None,
     return EMArray(EM)
 
 
-def dipole(src, rec, depth, res, freqtime, signal=None, ab=11, aniso=None,
-           epermH=None, epermV=None, mpermH=None, mpermV=None, xdirect=False,
-           ht='dlf', htarg=None, ft='sin', ftarg=None, loop=None, verb=2):
+def dipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
     r"""Return EM fields due to infinitesimal small EM dipoles.
 
     Calculate the electromagnetic frequency- or time-domain field due to
@@ -617,6 +633,10 @@ def dipole(src, rec, depth, res, freqtime, signal=None, ab=11, aniso=None,
             - 0 : Impulse time-domain response
             - +1 : Switch-on time-domain response
 
+    aniso : array_like, optional
+        Anisotropies lambda = sqrt(rho_v/rho_h) (-); #aniso = #res.
+        Defaults to ones.
+
     ab : int, optional
         Source-receiver configuration, defaults to 11.
 
@@ -637,10 +657,6 @@ def dipole(src, rec, depth, res, freqtime, signal=None, ab=11, aniso=None,
         + **receiver**  +-------+------+------+------+------+------+------+
         |               | **z** |  61  |  62  |  63  |  64  |  65  |  66  |
         +---------------+-------+------+------+------+------+------+------+
-
-    aniso : array_like, optional
-        Anisotropies lambda = sqrt(rho_v/rho_h) (-); #aniso = #res.
-        Defaults to ones.
 
     epermH, epermV : array_like, optional
         Relative horizontal/vertical electric permittivities
@@ -828,6 +844,23 @@ def dipole(src, rec, depth, res, freqtime, signal=None, ab=11, aniso=None,
        6.75287598e-14 -1.74922886e-13j   4.62724887e-14 -1.32266600e-13j]
 
     """
+
+    # Get kwargs.                           # => create a utils-fct for this
+    ab = kwargs.pop('ab', 11)               #
+    epermH = kwargs.pop('epermH', None)     #
+    epermV = kwargs.pop('epermV', None)     #
+    mpermH = kwargs.pop('mpermH', None)     #
+    mpermV = kwargs.pop('mpermV', None)     #
+    xdirect = kwargs.pop('xdirect', False)  #
+    ht = kwargs.pop('ht', 'dlf')            #
+    htarg = kwargs.pop('htarg', None)       #
+    ft = kwargs.pop('ft', 'dlf')            #
+    ftarg = kwargs.pop('ftarg', None)       #
+    loop = kwargs.pop('loop', None)         #
+    verb = kwargs.pop('verb', 2)            #
+    # Ensure no kwargs left.                #
+    if kwargs:                              #
+        print(f"WAAAAAAAAAAA LEFT **kwargs: {kwargs}")
 
     # === 1.  LET'S START ============
     t0 = printstartfinish(verb)
@@ -1711,8 +1744,11 @@ def gpr(src, rec, depth, res, freqtime, cf, gain=None, ab=11, aniso=None,
 
     # === 2. CALL DIPOLE ============
 
-    EM = dipole(src, rec, depth, res, freq, None, ab, aniso, epermH, epermV,
-                mpermH, mpermV, xdirect, ht, htarg, ft, ftarg, loop, verb)
+    inp = {'ab': ab, 'aniso': aniso, 'epermH': epermH, 'epermV': epermV,
+           'mpermH': mpermH, 'mpermV': mpermV, 'xdirect': xdirect, 'ht': ht,
+           'htarg': htarg, 'ft': ft, 'ftarg': ftarg, 'loop': loop,
+           'verb': verb}
+    EM = dipole(src, rec, depth, res, freq, **inp)
 
     # === 3. GPR STUFF
 

--- a/empymod/model.py
+++ b/empymod/model.py
@@ -61,13 +61,15 @@ from empymod.utils import (
         check_time, check_time_only, check_model, check_frequency,
         check_hankel, check_loop, check_dipole, check_bipole, check_ab,
         check_solution, get_abs, get_geo_fact, get_azm_dip, get_off_ang,
-        get_layer_nr, printstartfinish, conv_warning, EMArray)
+        get_layer_nr, get_kwargs, printstartfinish, conv_warning, EMArray)
 
 __all__ = ['bipole', 'dipole', 'loop', 'analytical', 'gpr', 'dipole_k', 'fem',
            'tem']
 
 
-def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
+def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None,
+           epermH=None, epermV=None, mpermH=None, mpermV=None, msrc=False,
+           srcpts=1, mrec=False, recpts=1, strength=0, **kwargs):
     r"""Return EM fields due to arbitrary rotated, finite length EM dipoles.
 
     Calculate the electromagnetic frequency- or time-domain field due to
@@ -381,27 +383,10 @@ def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
        6.75287598e-14 -1.74922886e-13j   4.62724887e-14 -1.32266600e-13j]
 
     """
-
-    # Get kwargs.                           # => create a utils-fct for this
-    epermH = kwargs.pop('epermH', None)     #
-    epermV = kwargs.pop('epermV', None)     #
-    mpermH = kwargs.pop('mpermH', None)     #
-    mpermV = kwargs.pop('mpermV', None)     #
-    msrc = kwargs.pop('msrc', False)        #
-    mrec = kwargs.pop('mrec', False)        #
-    srcpts = kwargs.pop('srcpts', 1)        #
-    recpts = kwargs.pop('recpts', 1)        #
-    strength = kwargs.pop('strength', 0)    #
-    xdirect = kwargs.pop('xdirect', False)  #
-    ht = kwargs.pop('ht', 'dlf')            #
-    htarg = kwargs.pop('htarg', None)       #
-    ft = kwargs.pop('ft', 'dlf')            #
-    ftarg = kwargs.pop('ftarg', None)       #
-    loop = kwargs.pop('loop', None)         #
-    verb = kwargs.pop('verb', 2)            #
-    # Ensure no kwargs left.                #
-    if kwargs:                              #
-        print(f"WAAAAAAAAAAA LEFT **kwargs: {kwargs}")
+    # Get kwargs with defaults.
+    out = get_kwargs(['xdirect', 'ht', 'htarg', 'ft', 'ftarg', 'loop', 'verb'],
+                     [False, 'dlf', None, 'dlf', None, None, 2], kwargs)
+    xdirect, ht, htarg, ft, ftarg, loop, verb = out
 
     # === 1.  LET'S START ============
     t0 = printstartfinish(verb)
@@ -576,7 +561,8 @@ def bipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
     return EMArray(EM)
 
 
-def dipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
+def dipole(src, rec, depth, res, freqtime, signal=None, ab=11, aniso=None,
+           epermH=None, epermV=None, mpermH=None, mpermV=None, **kwargs):
     r"""Return EM fields due to infinitesimal small EM dipoles.
 
     Calculate the electromagnetic frequency- or time-domain field due to
@@ -633,10 +619,6 @@ def dipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
             - 0 : Impulse time-domain response
             - +1 : Switch-on time-domain response
 
-    aniso : array_like, optional
-        Anisotropies lambda = sqrt(rho_v/rho_h) (-); #aniso = #res.
-        Defaults to ones.
-
     ab : int, optional
         Source-receiver configuration, defaults to 11.
 
@@ -657,6 +639,10 @@ def dipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
         + **receiver**  +-------+------+------+------+------+------+------+
         |               | **z** |  61  |  62  |  63  |  64  |  65  |  66  |
         +---------------+-------+------+------+------+------+------+------+
+
+    aniso : array_like, optional
+        Anisotropies lambda = sqrt(rho_v/rho_h) (-); #aniso = #res.
+        Defaults to ones.
 
     epermH, epermV : array_like, optional
         Relative horizontal/vertical electric permittivities
@@ -844,23 +830,10 @@ def dipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
        6.75287598e-14 -1.74922886e-13j   4.62724887e-14 -1.32266600e-13j]
 
     """
-
-    # Get kwargs.                           # => create a utils-fct for this
-    ab = kwargs.pop('ab', 11)               #
-    epermH = kwargs.pop('epermH', None)     #
-    epermV = kwargs.pop('epermV', None)     #
-    mpermH = kwargs.pop('mpermH', None)     #
-    mpermV = kwargs.pop('mpermV', None)     #
-    xdirect = kwargs.pop('xdirect', False)  #
-    ht = kwargs.pop('ht', 'dlf')            #
-    htarg = kwargs.pop('htarg', None)       #
-    ft = kwargs.pop('ft', 'dlf')            #
-    ftarg = kwargs.pop('ftarg', None)       #
-    loop = kwargs.pop('loop', None)         #
-    verb = kwargs.pop('verb', 2)            #
-    # Ensure no kwargs left.                #
-    if kwargs:                              #
-        print(f"WAAAAAAAAAAA LEFT **kwargs: {kwargs}")
+    # Get kwargs with defaults.
+    out = get_kwargs(['xdirect', 'ht', 'htarg', 'ft', 'ftarg', 'loop', 'verb'],
+                     [False, 'dlf', None, 'dlf', None, None, 2], kwargs)
+    xdirect, ht, htarg, ft, ftarg, loop, verb = out
 
     # === 1.  LET'S START ============
     t0 = printstartfinish(verb)
@@ -940,8 +913,7 @@ def dipole(src, rec, depth, res, freqtime, signal=None, aniso=None, **kwargs):
 
 def loop(src, rec, depth, res, freqtime, signal=None, aniso=None, epermH=None,
          epermV=None, mpermH=None, mpermV=None, mrec=True, recpts=1,
-         strength=0, xdirect=False, ht='dlf', htarg=None, ft='sin', ftarg=None,
-         loop=None, verb=2):
+         strength=0, **kwargs):
     r"""Return EM fields due to a magnetic source loop.
 
     Calculate the electromagnetic frequency- or time-domain field due to
@@ -1279,6 +1251,10 @@ def loop(src, rec, depth, res, freqtime, signal=None, aniso=None, epermH=None,
       -8.55487532e-13 +6.18402706e-13j  -5.15642408e-13 +4.99091919e-13j]
 
     """
+    # Get kwargs with defaults.
+    out = get_kwargs(['xdirect', 'ht', 'htarg', 'ft', 'ftarg', 'loop', 'verb'],
+                     [False, 'dlf', None, 'dlf', None, None, 2], kwargs)
+    xdirect, ht, htarg, ft, ftarg, loop, verb = out
 
     # === 1.  LET'S START ============
     t0 = printstartfinish(verb)
@@ -1466,7 +1442,7 @@ def loop(src, rec, depth, res, freqtime, signal=None, aniso=None, epermH=None,
 
 def analytical(src, rec, res, freqtime, solution='fs', signal=None, ab=11,
                aniso=None, epermH=None, epermV=None, mpermH=None, mpermV=None,
-               verb=2):
+               **kwargs):
     r"""Return analytical full- or half-space solution.
 
     Calculate the electromagnetic frequency- or time-domain field due to
@@ -1612,6 +1588,8 @@ def analytical(src, rec, res, freqtime, solution='fs', signal=None, ab=11,
        1.31469130e-10 -7.62770461e-11j   7.72342470e-11 -5.74534125e-11j
        4.61480481e-11 -4.36275540e-11j   2.76174038e-11 -3.32860932e-11j]
     """
+    # Get kwargs with defaults.
+    verb = get_kwargs(['verb', ], [2, ], kwargs)[0]
 
     # === 1.  LET'S START ============
     t0 = printstartfinish(verb)
@@ -1698,8 +1676,7 @@ def analytical(src, rec, res, freqtime, solution='fs', signal=None, ab=11,
 
 
 def gpr(src, rec, depth, res, freqtime, cf, gain=None, ab=11, aniso=None,
-        epermH=None, epermV=None, mpermH=None, mpermV=None, xdirect=False,
-        ht='quad', htarg=None, ft='fft', ftarg=None, loop=None, verb=2):
+        epermH=None, epermV=None, mpermH=None, mpermV=None, **kwargs):
     r"""Return Ground-Penetrating Radar signal.
 
     THIS FUNCTION IS EXPERIMENTAL, USE WITH CAUTION.
@@ -1732,6 +1709,11 @@ def gpr(src, rec, depth, res, freqtime, cf, gain=None, ab=11, aniso=None,
         GPR response
 
     """
+    # Get kwargs with defaults.
+    out = get_kwargs(['xdirect', 'ht', 'htarg', 'ft', 'ftarg', 'loop', 'verb'],
+                     [False, 'quad', None, 'fft', None, None, 2], kwargs)
+    xdirect, ht, htarg, ft, ftarg, loop, verb = out
+
     if verb > 2:
         print("   GPR             :  EXPERIMENTAL, USE WITH CAUTION")
         print(f"     > centre freq :  {cf}")
@@ -1744,11 +1726,10 @@ def gpr(src, rec, depth, res, freqtime, cf, gain=None, ab=11, aniso=None,
 
     # === 2. CALL DIPOLE ============
 
-    inp = {'ab': ab, 'aniso': aniso, 'epermH': epermH, 'epermV': epermV,
-           'mpermH': mpermH, 'mpermV': mpermV, 'xdirect': xdirect, 'ht': ht,
-           'htarg': htarg, 'ft': ft, 'ftarg': ftarg, 'loop': loop,
-           'verb': verb}
-    EM = dipole(src, rec, depth, res, freq, **inp)
+    EM = dipole(src=src, rec=rec, depth=depth, res=res, freqtime=freq, ab=ab,
+                aniso=aniso, epermH=epermH, epermV=epermV, mpermH=mpermH,
+                mpermV=mpermV, xdirect=xdirect, ht=ht, htarg=htarg, ft=ft,
+                ftarg=ftarg, loop=loop, verb=verb)
 
     # === 3. GPR STUFF
 
@@ -1782,7 +1763,7 @@ def gpr(src, rec, depth, res, freqtime, cf, gain=None, ab=11, aniso=None,
 
 
 def dipole_k(src, rec, depth, res, freq, wavenumber, ab=11, aniso=None,
-             epermH=None, epermV=None, mpermH=None, mpermV=None, verb=2):
+             epermH=None, epermV=None, mpermH=None, mpermV=None, **kwargs):
     r"""Return electromagnetic wavenumber-domain field.
 
     Calculate the electromagnetic wavenumber-domain field due to infinitesimal
@@ -1903,6 +1884,8 @@ def dipole_k(src, rec, depth, res, freq, wavenumber, ab=11, aniso=None,
        2.42062030e-10 -8.95356636e-10j   2.54406501e-10 -9.42218177e-10j
        2.67371420e-10 -9.91530051e-10j   2.80987292e-10 -1.04342036e-09j]
     """
+    # Get kwargs with defaults.
+    verb = get_kwargs(['verb', ], [2, ], kwargs)[0]
 
     # === 1.  LET'S START ============
     t0 = printstartfinish(verb)

--- a/empymod/utils.py
+++ b/empymod/utils.py
@@ -1506,8 +1506,10 @@ def get_geo_fact(ab, srcazm, srcdip, recazm, recdip, msrc, mrec):
 def get_layer_nr(inp, depth):
     r"""Get number of layer in which inp resides.
 
-    Note:
-    If zinp is on a layer interface, the layer above the interface is chosen.
+    .. note::
+
+        If zinp is on a layer interface, the layer above the interface is
+        chosen.
 
     This check-function is called from one of the modelling routines in
     :mod:`model`.  Consult these modelling routines for a detailed description
@@ -1804,6 +1806,76 @@ def get_azm_dip(inp, iz, ninpz, intpts, isdipole, strength, name, verb):
     return tout, azm, dip, g_w, intpts, inp_w
 
 
+def get_kwargs(names, defaults, kwargs):
+    """Return wanted parameters, check remaining.
+
+    1. Extracts parameters ``names`` from ``kwargs``, filling them with the
+       ``defaults``-value if it is not in ``kwargs``.
+    2. Check remaining kwargs;
+       - Raise an error if it is an unknown keyword;
+       - Print warning if it is a keyword from another routine (verb>0).
+
+    List of possible kwargs:
+
+    - ALL functions: src, rec, res, aniso, epermH, epermV, mpermH, mpermV, verb
+    - ONLY gpr: cf, gain
+    - ONLY bipole: msrc, srcpts
+    - ONLY dipole_k: freq, wavenumber
+    - ONLY analytical: solution
+    - ONLY bipole, loop: mrec, recpts, strength
+    - ONLY bipole, dipole, loop, gpr: ht, htarg, ft, ftarg, xdirect, loop
+    - ONLY bipole, dipole, loop, analytical: signal
+    - ONLY dipole, analytical, gpr, dipole_k: ab
+    - ONLY bipole, dipole, loop, gpr, dipole_k: depth
+    - ONLY bipole, dipole, loop, analytical, gpr: freqtime
+
+    Parameters
+    ----------
+    names: list
+        Names of wanted parameters as strings.
+
+    defaults: list
+        Default values of wanted parameters, in same order.
+
+    kwargs : dict
+        Passed-through kwargs.
+
+    Returns
+    ------
+    values : list
+        Wanted parameters.
+
+    """
+    # Known keys (excludes keys present in ALL routines).
+    known_keys = set([
+            'depth', 'ht', 'htarg', 'ft', 'ftarg', 'xdirect', 'loop', 'signal',
+            'ab', 'freqtime', 'freq', 'wavenumber', 'solution', 'cf', 'gain',
+            'msrc', 'srcpts', 'mrec', 'recpts', 'strength'
+    ])
+
+    # Loop over wanted parameters.
+    out = list()
+    verb = 2  # get_kwargs-internal default.
+    for i, name in enumerate(names):
+
+        # Catch verb for warnings later on.
+        if name == 'verb':
+            verb = kwargs.get(name, defaults[i])
+
+        # Add this parameter to the list.
+        out.append(kwargs.pop(name, defaults[i]))
+
+    # Check remaining parameters.
+    if kwargs:
+        if not set(kwargs.keys()).issubset(known_keys):
+            print(f"* ERROR   :: Unexpected **kwargs: {kwargs}")
+            raise ValueError('kwargs')
+        elif verb > 0:
+            print(f"* WARNING :: Unused **kwargs: {kwargs}")
+
+    return out
+
+
 def printstartfinish(verb, inp=None, kcount=None):
     r"""Print start and finish with time measure and kernel count."""
     if inp:
@@ -1837,6 +1909,11 @@ def set_minimum(min_freq=None, min_time=None, min_off=None, min_res=None,
 
     The given parameters are set to its minimum value if they are smaller.
 
+    .. note::
+
+        set_minimum and get_minimum are derived after set_printoptions and
+        get_printoptions from arrayprint.py in numpy.
+
     Parameters
     ----------
     min_freq : float, optional
@@ -1850,11 +1927,6 @@ def set_minimum(min_freq=None, min_time=None, min_off=None, min_res=None,
         Minimum horizontal and vertical resistivity [Ohm.m] (default 1e-20).
     min_angle : float, optional
         Minimum angle [-] (default 1e-10).
-
-    Note
-    ----
-    set_minimum and get_minimum are derived after set_printoptions and
-    get_printoptions from arrayprint.py in numpy.
 
     """
 
@@ -1876,6 +1948,11 @@ def get_minimum():
     r"""
     Return the current minimum values.
 
+    .. note::
+
+        set_minimum and get_minimum are derived after set_printoptions and
+        get_printoptions from arrayprint.py in numpy.
+
     Returns
     -------
     min_vals : dict
@@ -1888,11 +1965,6 @@ def get_minimum():
           - min_angle : float
 
         For a full description of these options, see `set_minimum`.
-
-    Note
-    ----
-    set_minimum and get_minimum are derived after set_printoptions and
-    get_printoptions from arrayprint.py in numpy.
 
     """
     d = dict(min_freq=_min_freq,
@@ -1999,6 +2071,11 @@ class Report(ScoobyReport):
 
     All modules provided in ``add_pckg`` are also shown.
 
+    .. note::
+
+        The package ``scooby`` has to be installed in order to use ``Report``:
+        ``pip install scooby``.
+
 
     Parameters
     ----------
@@ -2015,13 +2092,6 @@ class Report(ScoobyReport):
 
     sort : bool, optional
         Sort the packages when the report is shown
-
-
-    NOTE
-    ----
-
-    The package ``scooby`` has to be installed in order to use ``Report``:
-    ``pip install scooby``.
 
 
     Examples

--- a/examples/time_domain/ht_ft_with_other_modellers.py
+++ b/examples/time_domain/ht_ft_with_other_modellers.py
@@ -83,7 +83,7 @@ plt.show()
 # Calculate corresponding time-domain signal.
 tresp, _ = empymod.model.tem(
     fEM=fresp[:, None],
-    off=model['rec'][0],
+    off=np.array(model['rec'][0]),
     freq=freq,
     time=time,
     signal=signal,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -621,29 +621,26 @@ def test_all_depths():
     mpermV = [2.5, 2.6, 2.7, 2.8, 2.9]
 
     # 1. Ordering as internally used:
+    inp = {'ab': 11, 'aniso': aniso, 'epermH': epermH, 'epermV': epermV,
+           'mpermH': mpermH, 'mpermV': mpermV}
 
     # LHS low-to-high (+1, ::+1)
-    lhs_l2h = dipole(
-            src, rec, depth, res, freq, None, 11, aniso, epermH, epermV,
-            mpermH, mpermV)
+    lhs_l2h = dipole(src, rec, depth, res, freq, None, **inp)
 
     # RHS high-to-low (-1, ::+1)
-    rhs_h2l = dipole(
-            [src[0], src[1], -src[2]], [rec[0], rec[1], -rec[2]], -depth, res,
-            freq, None, 11, aniso, epermH, epermV, mpermH, mpermV)
+    rhs_h2l = dipole([src[0], src[1], -src[2]], [rec[0], rec[1], -rec[2]],
+                     -depth, res, freq, **inp)
 
     # 2. Reversed ordering:
+    inp_r = {'ab': 11, 'aniso': aniso[::-1], 'epermH': epermH[::-1], 'epermV':
+             epermV[::-1], 'mpermH': mpermH[::-1], 'mpermV': mpermV[::-1]}
 
     # LHS high-to-low (+1, ::-1)
-    lhs_h2l = dipole(
-            src, rec, depth[::-1], res[::-1], freq, None, 11, aniso[::-1],
-            epermH[::-1], epermV[::-1], mpermH[::-1], mpermV[::-1])
+    lhs_h2l = dipole(src, rec, depth[::-1], res[::-1], freq, **inp_r)
 
     # RHS low-to-high (-1, ::-1)
-    rhs_l2h = dipole(
-            [src[0], src[1], -src[2]], [rec[0], rec[1], -rec[2]], -depth[::-1],
-            res[::-1], freq, None, 11, aniso[::-1], epermH[::-1], epermV[::-1],
-            mpermH[::-1], mpermV[::-1])
+    rhs_l2h = dipole([src[0], src[1], -src[2]], [rec[0], rec[1], -rec[2]],
+                     -depth[::-1], res[::-1], freq, **inp_r)
 
     assert_allclose(lhs_l2h, lhs_h2l)
     assert_allclose(lhs_l2h, rhs_l2h)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -625,7 +625,7 @@ def test_all_depths():
            'mpermH': mpermH, 'mpermV': mpermV}
 
     # LHS low-to-high (+1, ::+1)
-    lhs_l2h = dipole(src, rec, depth, res, freq, None, **inp)
+    lhs_l2h = dipole(src, rec, depth, res, freq, **inp)
 
     # RHS high-to-low (-1, ::+1)
     rhs_h2l = dipole([src[0], src[1], -src[2]], [rec[0], rec[1], -rec[2]],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -936,6 +936,19 @@ def test_get_azm_dip(capsys):
     assert outstr[:47] == "   Receiver(s)     :  1 bipole(s)\n     > intpts"
 
 
+def test_get_kwargs(capsys):
+    kwargs1 = {'ft': 'sin', 'depth': []}
+    ft, ht = utils.get_kwargs(['ft', 'ht'], ['dlf', 'dlf'], kwargs1)
+    out, _ = capsys.readouterr()
+    assert ft == 'sin'
+    assert ht == 'dlf'
+    assert "* WARNING :: Unused **kwargs: {'depth': []}" in out
+
+    kwargs2 = {'depth': [], 'unknown': 1}
+    with pytest.raises(ValueError):
+        utils.get_kwargs(['verb', ], [0, ], kwargs2)
+
+
 def test_printstartfinish(capsys):
     t0 = utils.printstartfinish(0)
     assert isinstance(t0, float)


### PR DESCRIPTION
All settings (``xdirect``, ``ht``, ``htarg``, ``ft``, ``ftarg``, ``loop``, ``verb``) are now extracted from ``kwargs``. This makes it possible that all ``model``-functions take the same keyword-arguments; warnings are raised if a particular parameter is not used in this function, but it doesn't fail (it fails, however, for unknown parameters). Pure positional calls including those parameters will therefore not work any longer.
