### PR TITLE
Arbitrary Waveform

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,37 +39,37 @@ jobs:
           - python-version: "3.11"
             name: minimal
             os: ubuntu
-            conda: "numba 'scipy=1.10' scooby libdlf"
+            conda: "numba 'numpy==2.0.0' scipy scooby libdlf"
             test: ""
           - python-version: "3.12"
             name: plain
             os: ubuntu
-            conda: "numba 'scipy>=1.10' scooby libdlf"
+            conda: "numba 'numpy>=2.0.0' scipy scooby libdlf"
             test: ""
           - python-version: "3.12"
             name: full
             os: ubuntu
-            conda: "numba 'scipy>=1.10' scooby libdlf matplotlib pytest-mpl"
+            conda: "numba 'numpy>=2.0.0' scipy scooby libdlf matplotlib pytest-mpl"
             test: "--mpl"
           - python-version: "3.13"
             name: plain
             os: ubuntu
-            conda: "numba 'scipy>=1.10' scooby libdlf"
+            conda: "numba 'numpy>=2.0.0' scipy scooby libdlf"
             test: ""
           - python-version: "3.13"
             name: full
             os: ubuntu
-            conda: "numba 'scipy>=1.10' scooby libdlf matplotlib pytest-mpl"
+            conda: "numba 'numpy>=2.0.0' scipy scooby libdlf matplotlib pytest-mpl"
             test: "--mpl"
           - python-version: "3.14"
             name: plain
             os: ubuntu
-            conda: "numba 'scipy>=1.10' scooby libdlf"
+            conda: "numba 'numpy>=2.0.0' scipy scooby libdlf"
             test: ""
           - python-version: "3.14"
             name: full
             os: ubuntu
-            conda: "numba 'scipy>=1.10' scooby libdlf matplotlib pytest-mpl"
+            conda: "numba 'numpy>=2.0.0' scipy scooby libdlf matplotlib pytest-mpl"
             test: "--mpl"
 
     env:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,21 +17,31 @@ v2.5.x
 
   - ``bipole``:
 
-    - Arbitrary waveforms: Time-domain modelling can new be done not only for
-      impulse (``signal=0``), step-on (``signal=1``), and step-off
-      (``signal=-1``), but for any arbitrary piecewise linear waveform.
-
-    - Bandpass filters can now be applied to the frequency domain result
-      through user-provided functions. 
+    - Arbitrary waveforms: Time-domain modelling can new be done for any
+      arbitrary piecewise linear waveform, in addition to impulse
+      (``signal=0``), step-on (``signal=1``), and step-off (``signal=-1``)
+      responses.
+    - User-defined bandpass filters can now be applied to the frequency domain
+      result through user-provided functions.
 
   - Merged ``loop`` into ``bipole``; there is no need for a special routine.
     Simply use ``bipole`` with ``msrc='b'`` and ``mrec=True`` for the same
-    effect. As a result, ``empymod.utils.check_bipole`` changed its signature.
-    For ``bipole``, it new prints the source and receiver type (electric field,
-    magnetic field, magnetic flux, or electric current). Both,
-    ``empymod.model.loop`` and ``empymod.utils.check_bipole``'s old signature
-    are deprecated and will be removed in v3.
+    effect.
 
+- New prints (if verbose):
+
+  - The source/receiver types are new printed.
+  - The signal/waveform is new printed.
+
+- New function ``empymod.utils.check_waveform``, to check the waveform.
+
+- New deprecations (will be removed in v3):
+
+  - ``empymod.model.loop`` will be removed in v3.
+  - ``empymod.utils.check_bipole``: Now returns also the src/rec field and
+    type.
+  - ``empymod.utils.check_time``: Now also returns the signal.
+  - ``empymod.utils.check_time_only``: Now also returns the signal.
 
 
 v2.5.4: Bugfix ext. fcts with z+ up
@@ -152,7 +162,7 @@ The code is now compatible with NumPy v2.
 
 - Gallery Update Part I:
 
-  - Update for Jupyterlab (ipympl/widget) 
+  - Update for Jupyterlab (ipympl/widget)
   - Replaced implicit by explicit pyplots
   - Use by default a positiv z-upwards coordinate system
   - Part I: frequency domain; reproducing; published

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ v2.5.x
 
 - Modelling routines:
 
+  - Arbitrary waveforms: Time-domain modelling can new be done not only for
+    impulse (``signal=0``), step-on (``signal=1``), and step-off
+    (``signal=-1``), but for any arbitrary piecewise linear waveform.
   - Merged ``loop`` into ``bipole``; there is no need for a special routine.
     Simply use ``bipole`` with ``msrc='b'`` and ``mrec=True`` for the same
     effect. As a result, ``empymod.utils.check_bipole`` changed its signature.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,12 @@ v2.5.x
   - ``empymod.utils.check_time``: Now also returns the signal.
   - ``empymod.utils.check_time_only``: Now also returns the signal.
 
+- Bumped the minimum requirements to:
+
+  - Python 3.11
+  - NumPy 2.0
+  - SciPy, Numba, libdlf, scooby (without minimum version)
+
 
 v2.5.4: Bugfix ext. fcts with z+ up
 -----------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,16 @@ Version 2
 ~~~~~~~~~
 
 
-v2.5.x
+v2.6.x
 """"""
 
 
-*latest*
---------
+v2.6.0: Arbitrary waveforms
+---------------------------
+
+**2026-01-31**
+
+This version finally introduces the possibility for arbitrary waveforms.
 
 - Modelling routines:
 
@@ -38,16 +42,23 @@ v2.5.x
 - New deprecations (will be removed in v3):
 
   - ``empymod.model.loop`` will be removed in v3.
-  - ``empymod.utils.check_bipole``: Now returns also the src/rec field and
-    type.
-  - ``empymod.utils.check_time``: Now also returns the signal.
-  - ``empymod.utils.check_time_only``: Now also returns the signal.
+  - ``empymod.utils.check_bipole``: New signature, it now returns also the
+    src/rec field and
+    type; old signature will be removed in v3.
+  - ``empymod.utils.check_time``: New signature, it now also returns the
+    signal; old signature will be removed in v3.
+  - ``empymod.utils.check_time_only``: New signature, it now also returns the
+    signal; old signature will be removed in v3.
 
 - Bumped the minimum requirements to:
 
   - Python 3.11
   - NumPy 2.0
   - SciPy, Numba, libdlf, scooby (without minimum version)
+
+
+v2.5.x
+""""""
 
 
 v2.5.4: Bugfix ext. fcts with z+ up

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ v2.5.x
 
 - Modelling routines:
 
-  - ``bipole``:
+  - ``bipole`` and ``dipole``:
 
     - Arbitrary waveforms: Time-domain modelling can new be done for any
       arbitrary piecewise linear waveform, in addition to impulse

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,15 @@ v2.5.x
 
 - Modelling routines:
 
-  - Arbitrary waveforms: Time-domain modelling can new be done not only for
-    impulse (``signal=0``), step-on (``signal=1``), and step-off
-    (``signal=-1``), but for any arbitrary piecewise linear waveform.
+  - ``bipole``:
+
+    - Arbitrary waveforms: Time-domain modelling can new be done not only for
+      impulse (``signal=0``), step-on (``signal=1``), and step-off
+      (``signal=-1``), but for any arbitrary piecewise linear waveform.
+
+    - Bandpass filters can now be applied to the frequency domain result
+      through user-provided functions. 
+
   - Merged ``loop`` into ``bipole``; there is no need for a special routine.
     Simply use ``bipole`` with ``msrc='b'`` and ``mrec=True`` for the same
     effect. As a result, ``empymod.utils.check_bipole`` changed its signature.

--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -16,8 +16,8 @@ namely:
   Aleksander Mousatov.
 - 2018-2021: `Delft University of Technology <https://www.tudelft.nl>`_;
   through the *Gitaro.JIM* project (till 05/2021, emg3d v1.0.0), funded by
-  `MarTERA <https://www.martera.eu>`_ as part of Horizon 2020, a funding scheme
-  of the European Research Area.
+  MarTERA as part of Horizon 2020, a funding scheme of the European Research
+  Area.
 - 2021-2022: `TERRASYS Geophysics GmbH & Co. KG
   <https://www.terrasysgeo.com>`_.
 - 2021-2024: `Delft University of Technology <https://www.tudelft.nl>`_ through

--- a/docs/manual/info.rst
+++ b/docs/manual/info.rst
@@ -218,24 +218,22 @@ A common alternative to this trick is to apply a lowpass filter to filter out
 the unstable high frequencies.
 
 
-TEM / Loops
------------
+Loops (FEM/TEM)
+---------------
 
 The kernel of ``empymod`` computes the electric and magnetic Green's functions
 for infinitesimal small dipoles. Combining various of these small dipoles
 allows to model any kind of source and receiver configurations, including
-loops, as frequently used in TEM (time-domain EM) measurements. To make the
-correct assembly of dipoles is not always trivial, and the easiest way is
-probably to look for a similar example and modify it. Here a list of loop
-examples in the gallery:
+loops. To make the correct assembly of dipoles is not always trivial, and the
+easiest way is probably to look for a similar example and modify it. Here a
+list of loop examples in the gallery:
 
-- :ref:`sphx_glr_gallery_fdomain_ipandq.py` (f-domain, but loop equipments,
-  GEM-2 & DUALEM-842);
+- :ref:`sphx_glr_gallery_fdomain_ipandq.py` (GEM-2 & DUALEM-842);
 - :ref:`sphx_glr_gallery_tdomain_ip_vrm.py`;
-- :ref:`sphx_glr_gallery_tdomain_tem_temfast.py`;
-- :ref:`sphx_glr_gallery_tdomain_tem_walktem.py`;
+- :ref:`sphx_glr_gallery_tdomain_tem_temfast.py` (TEM-FAST);
+- :ref:`sphx_glr_gallery_tdomain_tem_walktem.py` (Walk-TEM);
 - :ref:`sphx_glr_gallery_educational_dipoles_and_loops.py`;
-- :ref:`sphx_glr_gallery_reproducing_ward1988.py` (f- & t-demain).
+- :ref:`sphx_glr_gallery_reproducing_ward1988.py`.
 
 
 Hook for user-defined computation of :math:`\eta` and :math:`\zeta`

--- a/docs/manual/info.rst
+++ b/docs/manual/info.rst
@@ -154,8 +154,8 @@ the example
 :ref:`sphx_glr_gallery_educational_dlf_standard_lagged_splined.py`.
 
 
-Looping
--------
+Looping to reduce memory
+------------------------
 
 By default, you can compute many offsets and many frequencies all in one go,
 vectorized (for the *DLF*), which is the default. The ``loop`` parameter gives
@@ -218,6 +218,26 @@ A common alternative to this trick is to apply a lowpass filter to filter out
 the unstable high frequencies.
 
 
+TEM / Loops
+-----------
+
+The kernel of ``empymod`` computes the electric and magnetic Green's functions
+for infinitesimal small dipoles. Combining various of these small dipoles
+allows to model any kind of source and receiver configurations, including
+loops, as frequently used in TEM (time-domain EM) measurements. To make the
+correct assembly of dipoles is not always trivial, and the easiest way is
+probably to look for a similar example and modify it. Here a list of loop
+examples in the gallery:
+
+- :ref:`sphx_glr_gallery_fdomain_ipandq.py` (f-domain, but loop equipments,
+  GEM-2 & DUALEM-842);
+- :ref:`sphx_glr_gallery_tdomain_ip_vrm.py`;
+- :ref:`sphx_glr_gallery_tdomain_tem_temfast.py`;
+- :ref:`sphx_glr_gallery_tdomain_tem_walktem.py`;
+- :ref:`sphx_glr_gallery_educational_dipoles_and_loops.py`;
+- :ref:`sphx_glr_gallery_reproducing_ward1988.py` (f- & t-demain).
+
+
 Hook for user-defined computation of :math:`\eta` and :math:`\zeta`
 -------------------------------------------------------------------
 
@@ -266,10 +286,45 @@ characteristics:
 And then you call ``empymod`` with ``res={'res': res-array, 'tau': tau,
 'func_eta': my_new_eta}``.
 
-Have a look at the corresponding example in the Gallery, where this hook is
-exploited in the low-frequency range to use the Cole-Cole model for IP
-computation. It could also be used in the high-frequency range to model
-dielectricity.
+Have a look at, e.g., the :ref:`sphx_glr_gallery_tdomain_cole_cole_ip.py`
+example in the Gallery, where this hook is exploited in the low-frequency range
+to use the Cole-Cole model for IP computation. It could also be used in the
+high-frequency range to model dielectricity.
+
+
+Hook for user-defined bandpass filter
+-------------------------------------
+
+Similar to the hooks described above, there is since ``empymod v2.6.0`` a hook
+to apply a bandpass filter (or any function) to the frequency domain result, by
+proving a specific dictionary as ``bandpass`` argument. The signature of the
+function must be ``func(inp, p_dict)``, where ``inp`` is the dictionary you
+provide, and ``p_dict`` is a dictionary that contains all parameters so far
+computed in empymod ``[locals()]``. Any change to the frequency domain result
+must be done in-place, and the function does not return anything. Refer to the
+time-domain loop examples in the gallery. The dictionary must contain at least
+the keyword ``'func'``, containing the actual function, but can contain any
+other parameters too.
+
+**Dummy example**
+
+.. code-block:: python
+
+    def my_bandpass(inp, p_dict):
+        # Your computations, using the parameters you provided
+        # in `inp` and the parameters from empymod in `p_dict`.
+        # In the example line below, we provide, e.g.,  inp["cutoff"]
+        # Modification must happen in-place to "EM", nothing is returned.
+
+        # Here just a simple cutoff to show the principle.
+        p_dict["EM"][p_inp["freq"] > inp["cutoff"] *= 0
+
+And then you call ``empymod`` with ``bandpass={"cutoff": 1e6, "func":
+my_bandpass}``.
+
+Have a look at, e.g., the :ref:`sphx_glr_gallery_tdomain_tem_walktem.py`
+example in the Gallery, where this hook is applied.
+
 
 
 Zero horizontal offset

--- a/docs/manual/installation.rst
+++ b/docs/manual/installation.rst
@@ -13,8 +13,8 @@ or via ``pip``:
 
    pip install empymod
 
-Requirements are the modules ``numpy``, ``scipy``, ``numba``, ``libdlf``, and
-``scooby``.
+Requirements are the modules ``numpy>=2.0.0``, ``scipy``, ``numba``,
+``libdlf``, and ``scooby``.
 
 The modeller empymod comes with add-ons (``empymod.scripts``). These add-ons
 provide some very specific, additional functionalities. Some of these add-ons

--- a/docs/manual/references.rst
+++ b/docs/manual/references.rst
@@ -42,9 +42,7 @@ References
 .. [Key09] Key, K., 2009, 1D inversion of multicomponent, multifrequency marine
    CSEM data: Methodology and synthetic studies for resolving thin resistive
    layers: Geophysics, 74(2), F9--F20; DOI: `10.1190/1.3058434
-   <https://doi.org/10.1190/1.3058434>`_. Software:
-   `marineemlab.ucsd.edu/Projects/Occam/1DCSEM
-   <https://marineemlab.ucsd.edu/Projects/Occam/1DCSEM>`_.
+   <https://doi.org/10.1190/1.3058434>`_.
 .. [Key12] Key, K., 2012, Is the fast Hankel transform faster than quadrature?:
    Geophysics, 77(3), F21--F30; DOI: `10.1190/geo2011-0237.1
    <https://doi.org/10.1190/geo2011-0237.1>`_; Software:

--- a/docs/manual/references.rst
+++ b/docs/manual/references.rst
@@ -20,7 +20,7 @@ References
 .. [Ghos70] Ghosh, D. P.,  1970, The application of linear filter theory to the
    direct interpretation of geoelectrical resistivity measurements: Ph.D.
    Thesis, TU Delft; UUID: `88a568bb-ebee-4d7b-92df-6639b42da2b2
-   <http://resolver.tudelft.nl/uuid:88a568bb-ebee-4d7b-92df-6639b42da2b2>`_.
+   <https://resolver.tudelft.nl/uuid:88a568bb-ebee-4d7b-92df-6639b42da2b2>`_.
 .. [GuSi97] Guptasarma, D., and B. Singh, 1997, New digital linear filters for
    Hankel J0 and J1 transforms: Geophysical Prospecting, 45, 745--762; DOI:
    `10.1046/j.1365-2478.1997.500292.x

--- a/empymod/model.py
+++ b/empymod/model.py
@@ -820,7 +820,8 @@ def dipole(src, rec, depth, res, freqtime, signal=None, ab=11, aniso=None,
     # Check times and Fourier Transform arguments, get required frequencies
     # (freq = freqtime if `signal=None`)
     if signal is not None:
-        time, freq, ft, ftarg = check_time(freqtime, signal, ft, ftarg, verb)
+        out = check_time(freqtime, signal, ft, ftarg, verb, True)
+        time, freq, ft, ftarg, _ = out
     else:
         freq = freqtime
 
@@ -1084,7 +1085,7 @@ def analytical(src, rec, res, freqtime, solution='fs', signal=None, ab=11,
 
     # Check times or frequencies
     if signal is not None:
-        freqtime = check_time_only(freqtime, signal, verb)
+        freqtime, _ = check_time_only(freqtime, signal, verb, True)
 
     # Check layer parameters
     model = check_model([], res, aniso, epermH, epermV, mpermH, mpermV, True,
@@ -1218,7 +1219,7 @@ def gpr(src, rec, depth, res, freqtime, cf, gain=None, ab=11, aniso=None,
     # === 1.  CHECK TIME ============
 
     # Check times and Fourier Transform arguments, get required frequencies
-    time, freq, ft, ftarg = check_time(freqtime, 0, ft, ftarg, verb)
+    time, freq, ft, ftarg, _ = check_time(freqtime, 0, ft, ftarg, verb, True)
 
     # === 2. CALL DIPOLE ============
 

--- a/empymod/utils.py
+++ b/empymod/utils.py
@@ -1979,15 +1979,15 @@ def get_kwargs(names, defaults, kwargs):
 
     - ALL functions: src, rec, res, aniso, epermH, epermV, mpermH, mpermV, verb
     - ONLY gpr: cf, gain
-    - ONLY bipole: msrc, srcpts, bandpass
+    - ONLY bipole: msrc, srcpts, mrec, recpts, strength
+    - ONLY bipole, dipole: bandpass
     - ONLY dipole_k: freq, wavenumber
     - ONLY analytical: solution
-    - ONLY bipole, loop: mrec, recpts, strength
-    - ONLY bipole, dipole, loop, gpr: ht, htarg, ft, ftarg, xdirect, loop
-    - ONLY bipole, dipole, loop, analytical: signal, squeeze
+    - ONLY bipole, dipole, gpr: ht, htarg, ft, ftarg, xdirect, loop
+    - ONLY bipole, dipole, analytical: signal, squeeze
     - ONLY dipole, analytical, gpr, dipole_k: ab
-    - ONLY bipole, dipole, loop, gpr, dipole_k: depth
-    - ONLY bipole, dipole, loop, analytical, gpr: freqtime
+    - ONLY bipole, dipole, gpr, dipole_k: depth
+    - ONLY bipole, dipole, analytical, gpr: freqtime
 
     Parameters
     ----------

--- a/empymod/utils.py
+++ b/empymod/utils.py
@@ -1443,6 +1443,11 @@ def check_waveform(time, nodes, amplitudes, verb, signal=0, nquad=3):
     comp_time_flat, map_time = np.unique(comp_time, return_inverse=True)
     comp_time_flat[comp_time_flat < _min_time] = _min_time
 
+    if comp_time_flat.size == 0:
+        raise ValueError(
+            "All wanted times are before provided waveform; aborting."
+        )
+
     def apply_waveform(resp):
         """Waveform function."""
 

--- a/examples/time_domain/step_and_impulse.py
+++ b/examples/time_domain/step_and_impulse.py
@@ -59,7 +59,7 @@ colors = [color['color'] for color in list(plt.rcParams['axes.prop_cycle'])]
 # Equations 3.2 and 3.3 in Werthmüller, D., 2009, Inversion of multi-transient
 # EM data from anisotropic media: M.S. thesis, TU Delft, ETH Zürich, RWTH
 # Aachen; UUID: `f4b071c1-8e55-4ec5-86c6-a2d54c3eda5a
-# <https://repository.tudelft.nl/islandora/object/uuid:f4b071c1-8e55-4ec5-86c6-a2d54c3eda5a>`_.
+# <https://resolver.tudelft.nl/uuid:f4b071c1-8e55-4ec5-86c6-a2d54c3eda5a>`_.
 #
 # Analytical functions
 # ~~~~~~~~~~~~~~~~~~~~

--- a/examples/time_domain/tem_temfast.py
+++ b/examples/time_domain/tem_temfast.py
@@ -5,10 +5,10 @@ TEM: AEMR TEM-FAST 48 system
 **In this example we compute the TEM response from the TEM-FAST 48 system.**
 
 This example was contributed by Lukas Aigner (`@aignerlukas
-<https://github.com/aignerlukas>`_), who was interested
-in modelling the TEM-FAST system, which is used at the TU Wien.
-If you are interested and want to use this work please have a look at the
-corresponding paper Aigner et al. (2024).
+<https://github.com/aignerlukas>`_), who was interested in modelling the
+TEM-FAST system, which is used at the TU Wien. If you are interested and want
+to use this work please have a look at the corresponding paper Aigner et al.
+(2024).
 
 The modeller ``empymod`` models the electromagnetic (EM) full wavefield Greens
 function for electric and magnetic point sources and receivers. As such, it can
@@ -16,12 +16,8 @@ model any EM method from DC to GPR. However, how to actually implement a
 particular EM method and survey layout can be tricky, as there are many more
 things involved than just computing the EM Greens function.
 
-What is not included in ``empymod`` at this moment (but hopefully in the
-future), but is required to model TEM data, is to **account for arbitrary
-source waveform**, and to apply a **lowpass filter**. So we generate these two
-things here, and create our own wrapper to model TEM data. See also the example
-:ref:`sphx_glr_gallery_tdomain_tem_walktem.py`, on which this example
-builds upon.
+See also the example :ref:`sphx_glr_gallery_tdomain_tem_walktem.py`, on which
+this example builds upon.
 
 **References**
 
@@ -36,10 +32,9 @@ builds upon.
 import empymod
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.special import roots_legendre
-from matplotlib.ticker import LogLocator, NullFormatter
-from scipy.interpolate import InterpolatedUnivariateSpline as iuSpline
+
 plt.style.use('ggplot')
+
 # sphinx_gallery_thumbnail_number = 2
 
 ###############################################################################
@@ -49,257 +44,99 @@ plt.style.use('ggplot')
 # The TEM-FASt system uses a "time-key" value to determine the number of gates,
 # the front ramp and the length of the current pulse.
 # We are using values that correspond to a time-key of 5.
-turn_on_ramp = -3.0E-06
-turn_off_ramp = 0.95E-06
-on_time = 3.75E-03
+turn_on_ramp = -3e-6
+turn_off_ramp = 0.95e-6
+on_time = 3.75e-3
 
 injected_current = 4.1  # Ampere
-time_gates = np.r_[4.060e+00, 5.070e+00, 6.070e+00, 7.080e+00,
-                   8.520e+00, 1.053e+01, 1.255e+01, 1.456e+01,
-                   1.744e+01, 2.146e+01, 2.549e+01, 2.950e+01,
-                   3.528e+01, 4.330e+01, 5.140e+01, 5.941e+01,  # time-key 1
-                   7.160e+01, 8.760e+01, 1.036e+02, 1.196e+02,  # time-key 2
-                   1.436e+02, 1.756e+02, 2.076e+02, 2.396e+02,  # time-key 3
-                   2.850e+02, 3.500e+02, 4.140e+02, 4.780e+02,  # time-key 4
-                   5.700e+02, 6.990e+02, 8.280e+02, 9.560e+02,  # time-key 5
-                   ] * 1e-6  # from us to s
+time_gates = np.array([
+    4.060e+00, 5.070e+00, 6.070e+00, 7.080e+00,
+    8.520e+00, 1.053e+01, 1.255e+01, 1.456e+01,
+    1.744e+01, 2.146e+01, 2.549e+01, 2.950e+01,
+    3.528e+01, 4.330e+01, 5.140e+01, 5.941e+01,  # time-key 1
+    7.160e+01, 8.760e+01, 1.036e+02, 1.196e+02,  # time-key 2
+    1.436e+02, 1.756e+02, 2.076e+02, 2.396e+02,  # time-key 3
+    2.850e+02, 3.500e+02, 4.140e+02, 4.780e+02,  # time-key 4
+    5.700e+02, 6.990e+02, 8.280e+02, 9.560e+02,  # time-key 5
+]) * 1e-6  # from us to s
 
-waveform_times = np.r_[turn_on_ramp - on_time, -on_time,
-                       0.000E+00, turn_off_ramp]
-waveform_current = np.r_[0.0, injected_current, injected_current, 0.0]
+nodes = np.array([turn_on_ramp - on_time, -on_time, 0, turn_off_ramp])
+amplitudes = np.array([0.0, injected_current, injected_current, 0.0])
 
-plt.figure()
-plt.title('Waveform')
-plt.plot(np.r_[-9, waveform_times*1e3, 2], np.r_[0, waveform_current, 0])
-plt.xlabel('Time (ms)')
-plt.xlim([-4, 0.5])
+fig, ax = plt.subplots(1, 1, constrained_layout=True)
+ax.set_title('Waveform')
+ax.plot(np.r_[-5, nodes*1e3, 1.5], np.r_[0, amplitudes, 0])
+ax.set_xlabel('Time (ms)')
+ax.set_xlim([-5, 1.5])
 
 
 ###############################################################################
 # 2. ``empymod`` implementation
 # -----------------------------
-def waveform(times, resp, times_wanted, wave_time, wave_amp, nquad=3):
-    """Apply a source waveform to the signal.
+#
+# Here we collect the necessary input for empymod to model temfast.
 
-    Parameters
-    ----------
-    times : ndarray
-        Times of computed input response; should start before and end after
-        `times_wanted`.
-
-    resp : ndarray
-        EM-response corresponding to `times`.
-
-    times_wanted : ndarray
-        Wanted times.
-
-    wave_time : ndarray
-        Time steps of the wave.
-
-    wave_amp : ndarray
-        Amplitudes of the wave corresponding to `wave_time`, usually
-        in the range of [0, 1].
-
-    nquad : int
-        Number of Gauss-Legendre points for the integration. Default is 3.
-
-    Returns
-    -------
-    resp_wanted : ndarray
-        EM field for `times_wanted`.
-
-    """
-
-    # Interpolate on log.
-    PP = iuSpline(np.log10(times), resp)
-
-    # Wave time steps.
-    dt = np.diff(wave_time)
-    dI = np.diff(wave_amp)
-    dIdt = dI/dt
-
-    # Gauss-Legendre Quadrature; 3 is generally good enough.
-    # (Roots/weights could be cached.)
-    g_x, g_w = roots_legendre(nquad)
-
-    # Pre-allocate output.
-    resp_wanted = np.zeros_like(times_wanted)
-
-    # Loop over wave segments.
-    for i, cdIdt in enumerate(dIdt):
-
-        # We only have to consider segments with a change of current.
-        if cdIdt == 0.0:
-            continue
-
-        # If wanted time is before a wave element, ignore it.
-        ind_a = wave_time[i] < times_wanted
-        if ind_a.sum() == 0:
-            continue
-
-        # If wanted time is within a wave element, we cut the element.
-        ind_b = wave_time[i+1] > times_wanted[ind_a]
-
-        # Start and end for this wave-segment for all times.
-        ta = times_wanted[ind_a]-wave_time[i]
-        tb = times_wanted[ind_a]-wave_time[i+1]
-        tb[ind_b] = 0.0  # Cut elements
-
-        # Gauss-Legendre for this wave segment. See
-        # https://en.wikipedia.org/wiki/Gaussian_quadrature#Change_of_interval
-        # for the change of interval, which makes this a bit more complex.
-        logt = np.log10(np.outer((tb-ta)/2, g_x)+(ta+tb)[:, None]/2)
-        fact = (tb-ta)/2*cdIdt
-        resp_wanted[ind_a] += fact*np.sum(np.array(PP(logt)*g_w), axis=1)
-
-    return resp_wanted
+def bandpass(inp, p_dict):
+    """Butterworth-type filter (implemented from simpegEM1D.Waveforms.py)."""
+    cutofffreq = 1e8  # Determined empirically for TEM-FAST
+    h = (1 + 1j*p_dict["freq"]/cutofffreq)**-1
+    h *= (1 + 1j*p_dict["freq"]/3e5)**-1
+    p_dict["EM"] *= h[:, None]
 
 
-###############################################################################
-def get_time(time, r_time):
-    """Additional time for ramp.
-
-    Because of the arbitrary waveform, we need to compute some times before and
-    after the actually wanted times for interpolation of the waveform.
-
-    Some implementation details: The actual times here don't really matter. We
-    create a vector of time.size+2, so it is similar to the input times and
-    accounts that it will require a bit earlier and a bit later times. Really
-    important are only the minimum and maximum times. The Fourier DLF, with
-    `pts_per_dec=-1`, computes times from minimum to at least the maximum,
-    where the actual spacing is defined by the filter spacing. It subsequently
-    interpolates to the wanted times. Afterwards, we interpolate those again to
-    compute the actual waveform response.
-
-    Note: We could first call `waveform`, and get the actually required times
-          from there. This would make this function obsolete. It would also
-          avoid the double interpolation, first in `empymod.model.time` for the
-          Fourier DLF with `pts_per_dec=-1`, and second in `waveform`. Doable.
-          Probably not or marginally faster. And the code would become much
-          less readable.
-
-    Parameters
-    ----------
-    time : ndarray
-        Desired times
-
-    r_time : ndarray
-        Waveform times
-
-    Returns
-    -------
-    time_req : ndarray
-        Required times
-    """
-    tmin = np.log10(max(time.min()-r_time.max(), 1e-10))
-    tmax = np.log10(time.max()-r_time.min())
-    return np.logspace(tmin, tmax, time.size+2)
-
-
-###############################################################################
-def temfast(off_time, waveform_times, model, square_side=12.5):
+def temfast(depth, res):
     """Custom wrapper of empymod.model.bipole.
 
     Here, we compute TEM-FAST data using the ``empymod.model.bipole`` routine
-    as an example. This function is based upon the Walk TEM example.
-
-    We model the big source square loop by computing only half of one side of
-    the electric square loop and approximating the finite length dipole with 3
-    point dipole sources. The result is then multiplied by 8, to account for
-    all eight half-sides of the square loop.
-
-    The implementation here assumes a central loop configuration, where the
-    receiver (1 m2 area) is at the origin, and the source is a
-    square_side x square_side m electric loop, centered around the origin.
-
-    Note: This approximation of only using half of one of the four sides
-          obviously only works for central, horizontal square loops. If your
-          loop is arbitrary rotated, then you have to model all four sides of
-          the loop and sum it up.
+    as an example. Everything is fixed except for the depth and the resistivity
+    models.
 
 
     Parameters
     ----------
-    off_time : ndarray
-        times at which the secondary magnetic field will be measured
-
-    waveform_times : ndarray
-        Depths of the resistivity model (see ``empymod.model.bipole`` for more
-        info.)
-
     depth : ndarray
-        Depths of the resistivity model (see ``empymod.model.bipole`` for more
-        info.)
+        Depths of the resistivity model interfaces (see
+        ``empymod.model.bipole`` for more info).
 
     res : ndarray
         Resistivities of the resistivity model (see ``empymod.model.bipole``
-        for more info.)
-
-    square_side : float
-        sige length of the square loop in meter.
+        for more info).
 
     Returns
     -------
-    TEM-FAST waveform : EMArray
-        TEM-FAST response (dB/dt).
+    TEM-FAST : EMArray
+        TEM-FAST response [dB/dt].
 
     """
 
-    if 'm' in model:
-        depth = model['depth']
-        res = model
-        del res['depth']
-    else:
-        res = model['res']
-        depth = model['depth']
+    # The waveform signal
+    signal = {'nodes': nodes, 'amplitudes': amplitudes, 'signal': 1}
 
-    # === GET REQUIRED TIMES ===
-    time = get_time(off_time, waveform_times)
-
-    # === GET REQUIRED FREQUENCIES ===
-    time, freq, ft, ftarg = empymod.utils.check_time(
-        time=time,          # Required times
-        signal=1,           # Switch-on response
-        ft='dlf',           # Use DLF
-        ftarg={'dlf': 'key_601_2009'},
-        verb=2,
-    )
-
-    # === COMPUTE FREQUENCY-DOMAIN RESPONSE ===
+    # === COMPUTE RESPONSE ===
     # We only define a few parameters here. You could extend this for any
     # parameter possible to provide to empymod.model.bipole.
+
+    # We model the square with 1/2 of one side. This makes it faster, but it
+    # will only work for a horizontal square loop, with a central receiver.
+    square_side = 12.5
     hs = square_side / 2  # half side length
+
     EM = empymod.model.bipole(
-        src=[hs, hs,   0, hs, 0, 0],  # El. dipole source; half of one side.
-        rec=[0, 0, 0, 0, 90],         # Receiver at the origin, vertical.
-        depth=depth,                  # Depth-model, including air-interface.
-        res=res,                      # if with IP, res is a dictionary with
-                                      # all params and the function
-        freqtime=freq,                # Required frequencies.
-        mrec=True,                    # It is an el. source, but a magn. rec.
-        strength=8,                   # To account for 4 sides of square loop.
-        srcpts=3,                     # Approx. the finite dip. with 3 points.
-        htarg={'dlf': 'key_401_2009'},  # Short filter, so fast.
+        src=[hs, hs, 0, hs, 0, 0],  # El. dipole source; half of one side.
+        rec=[0, 0, 0, 0, 90],       # Receiver at the origin, vertical.
+        depth=depth,                # Depth-model.
+        res=res,                    # Resistivity model.
+        freqtime=time_gates,        # Wanted times.
+        signal=signal,              # Waveform
+        mrec="b",                   # Receiver: dB/dt
+        strength=8,                 # To account for 8 quarters of square.
+        srcpts=3,                   # Approx. the finite dip. with 3 points.
+        ftarg={"dlf": "key_81_2009"},  # Shorter, faster filters.
+        htarg={"dlf": "key_101_2009", "pts_per_dec": -1},
+        bandpass={"func": bandpass},
     )
 
-    # Multiply the frequecny-domain result with
-    # \mu for H->B, and i\omega for B->dB/dt.
-    EM *= 2j*np.pi*freq*4e-7*np.pi
-
-    # === Butterworth-type filter (implemented from simpegEM1D.Waveforms.py)===
-    cutofffreq = 1e8                 # determined empirically for TEM-FAST
-    h = (1+1j*freq/cutofffreq)**-1   # First order type
-    h *= (1+1j*freq/3e5)**-1
-    EM *= h
-
-    # === CONVERT TO TIME DOMAIN ===
-    delay_rst = 0                    # unknown for TEM-FAST, therefore 0
-    EM, _ = empymod.model.tem(EM[:, None], np.array([1]),
-                              freq, time+delay_rst, 1, ft, ftarg)
-    EM = np.squeeze(EM)
-
-    # === APPLY WAVEFORM ===
-    return waveform(time, EM, off_time, waveform_times, waveform_current)
+    return EM
 
 
 ###############################################################################
@@ -313,7 +150,7 @@ def pelton_res(inp, p_dict):
     # print('\n   shape: p_dict["freq"]\n', p_dict['freq'].shape)
     iwtc = np.outer(2j*np.pi*p_dict['freq'], inp['tau'])**inp['c']
 
-    rhoH = inp['rho_0'] * (1 - inp['m']*(1 - 1/(1 + iwtc)))
+    rhoH = inp['res'] * (1 - inp['m']*(1 - 1/(1 + iwtc)))
     rhoV = rhoH*p_dict['aniso']**2
 
     # Add electric permittivity contribution
@@ -324,77 +161,50 @@ def pelton_res(inp, p_dict):
 
 
 ###############################################################################
-# 3. Computation non-IP
-# ---------------------
-
-depths = [8, 20]
-rhos = [25, 5, 50]
-model = {'depth': np.r_[0, depths],
-         'res': np.r_[2e14, rhos]}
-
-# Compute conductive model
-response = temfast(off_time=time_gates, waveform_times=waveform_times,
-                   model=model)
-
-
-###############################################################################
-# 4. Computation with IP
+# 3. Computate responses
 # ----------------------
-depths = [8, 20]
-rhos = [25, 5, 50]
-charg = np.r_[0, 0.9, 0]
-taus = np.r_[1e-6, 5e-4, 1e-6]
-cs = np.r_[0, 0.9, 0]
 
-eta_func = pelton_res
-depth = np.r_[0, depths]
-model = {'depth': depth,
-         'res': np.r_[2e14, rhos],
-         'rho_0': np.r_[2e14, rhos],
-         'm': np.r_[0, charg],
-         'tau': np.r_[1e-7, taus],
-         'c': np.r_[0.01, cs],
-         'func_eta': eta_func}
+depth = [0, 8, 20]
+rhos = [2e14, 25, 5, 50]
 
+rhos_ip = {
+    'res': rhos,
+    'm': np.array([0, 0, 0.9, 0]),
+    'tau': np.array([1e-7, 1e-6, 5e-4, 1e-6]),
+    'c': np.array([0.01, 0, 0.9, 0]),
+    'func_eta': pelton_res,
+}
 
 # Compute conductive model
-response_ip = temfast(off_time=time_gates, waveform_times=waveform_times,
-                      model=model)
+response = temfast(depth=depth, res=rhos)
+
+# Compute conductive model
+response_ip = temfast(depth=depth, res=rhos_ip)
 
 
 ###############################################################################
-# 5. Comparison
+# 4. Comparison
 # -------------
 
-plt.figure(figsize=(5, 5), constrained_layout=True)
+fig, ax = plt.subplots(1, 1, constrained_layout=True)
 
-# Plot result of model 1
-ax1 = plt.subplot(111)
-plt.title('TEM-FAST responses')
+ax.set_title('TEM-FAST responses')
 
 # empymod
-plt.plot(time_gates, response, 'r.--', ms=7, label="response")
-plt.plot(time_gates, abs(response_ip), 'kx:', ms=7, label="response with IP")
+ax.loglog(time_gates, response, 'r.--', ms=7, label="response")
+ax.loglog(time_gates, abs(response_ip), 'kx:', ms=7, label="response with IP")
 
 sub0 = response_ip[response_ip < 0]
 tg_sub0 = time_gates[response_ip < 0]
-plt.plot(tg_sub0, abs(sub0), marker='s', ls='none',
-         mfc='none', ms=8, mew=1,
-         mec='c', label="negative readings")
+ax.loglog(tg_sub0, abs(sub0), marker='s', ls='none', mfc='none',
+          ms=8, mew=1, mec='c', label="negative readings")
 
 # Plot settings
-plt.xscale('log')
-plt.yscale('log')
-plt.xlabel("Time(s)")
-plt.ylabel(r"$\mathrm{d}\mathrm{B}_\mathrm{z}\,/\,\mathrm{d}t$")
-plt.grid(which='both', c='w')
-plt.legend(title='Data', loc=1)
+ax.set_xlabel("Time(s)")
+ax.set_ylabel(r"$\mathrm{d}\mathrm{B}_\mathrm{z}\,/\,\mathrm{d}t$")
+ax.grid(which='both')
+ax.legend()
 
-
-# Force minor ticks on logscale
-ax1.yaxis.set_minor_locator(LogLocator(subs='all', numticks=20))
-ax1.yaxis.set_minor_formatter(NullFormatter())
-plt.grid(which='both', c='w')
 
 ###############################################################################
 empymod.Report()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "empymod"
 description = "Open-source full 3D electromagnetic modeller for 1D VTI media"
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
   {name = "The emsig community", email = "info@emsig.xyz"},
 ]
 dependencies = [
-    "numpy",
-    "scipy>=1.10",
+    "numpy>=2.0.0",
+    "scipy",
     "numba",
     "libdlf",
     "scooby",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -611,7 +611,8 @@ def test_check_time(capsys):
     # pts_per_dec
     out, _ = capsys.readouterr()  # clear buffer
     with pytest.warns(DeprecationWarning, match='in v3.0.'):
-        _, _, _, ftarg = utils.check_time(time, 0, 'dlf', {'pts_per_dec': 30}, 4)
+        _, _, _, ftarg = utils.check_time(
+            time, 0, 'dlf', {'pts_per_dec': 30}, 4)
     assert ftarg['dlf'].name == filters.Fourier().key_201_2012.name
     assert ftarg['pts_per_dec'] == 30
     assert ftarg['kind'] == 'sin'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -559,7 +559,8 @@ def test_check_time(capsys):
 
     # # DLF # #
     # verbose
-    _, f, ft, ftarg = utils.check_time(time, 0, 'dlf', {}, 4)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, f, ft, ftarg = utils.check_time(time, 0, 'dlf', {}, 4)
     out, _ = capsys.readouterr()
     assert "   time        [s] :  3" in out
     assert "   Fourier         :  DLF (Sine-Filter)" in out
@@ -579,12 +580,14 @@ def test_check_time(capsys):
     assert ftarg['kind'] == 'sin'
 
     # filter-string and unknown parameter
-    _, f, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, f, _, ftarg = utils.check_time(
             time, -1, 'dlf',
             {'dlf': 'key_201_2012', 'kind': 'cos', 'notused': 1},
             4)
     out, _ = capsys.readouterr()
     outstr = "   time        [s] :  3\n"
+    outstr = "   signal          :  -1\n"
     outstr += "   Fourier         :  DLF (Cosine-Filter)\n     > Filter"
     assert outstr in out
     assert "WARNING :: Unknown ftarg {'notused': 1} for method 'dlf'" in out
@@ -597,7 +600,8 @@ def test_check_time(capsys):
     assert ftarg['kind'] == 'cos'
 
     # filter instance
-    _, _, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(
             time, 1, 'dlf',
             {'dlf': filters.Fourier().key_201_2012, 'kind': 'sin'}, 0)
     assert ftarg['dlf'].name == filters.Fourier().key_201_2012.name
@@ -606,7 +610,8 @@ def test_check_time(capsys):
 
     # pts_per_dec
     out, _ = capsys.readouterr()  # clear buffer
-    _, _, _, ftarg = utils.check_time(time, 0, 'dlf', {'pts_per_dec': 30}, 4)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(time, 0, 'dlf', {'pts_per_dec': 30}, 4)
     assert ftarg['dlf'].name == filters.Fourier().key_201_2012.name
     assert ftarg['pts_per_dec'] == 30
     assert ftarg['kind'] == 'sin'
@@ -614,7 +619,8 @@ def test_check_time(capsys):
     assert "     > DLF type    :  Splined, 30.0 pts/dec" in out
 
     # filter-string and pts_per_dec
-    _, _, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(
             time, 0, 'dlf',
             {'dlf': 'key_81_2009', 'pts_per_dec': -1, 'kind': 'cos'}, 4)
     out, _ = capsys.readouterr()
@@ -624,7 +630,8 @@ def test_check_time(capsys):
     assert ftarg['kind'] == 'cos'
 
     # pts_per_dec
-    _, freq, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, freq, _, ftarg = utils.check_time(
             time, 0, 'dlf', {'pts_per_dec': 0, 'kind': 'sin'}, 4)
     out, _ = capsys.readouterr()
     assert "     > DLF type    :  Standard" in out
@@ -633,7 +640,8 @@ def test_check_time(capsys):
     assert_allclose(np.ravel(f_base/(2*np.pi*time[:, None])), freq)
 
     # filter-string and pts_per_dec
-    _, _, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(
             time, 0, 'dlf',
             {'dlf': 'key_81_2009', 'pts_per_dec': 50, 'kind': 'cos'}, 0)
     assert ftarg['dlf'].name == filters.Fourier().key_81_2009.name
@@ -641,7 +649,8 @@ def test_check_time(capsys):
     assert ftarg['kind'] == 'cos'
 
     # just kind
-    _, f, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, f, _, ftarg = utils.check_time(
             time, 0, 'dlf', {'kind': 'sin'}, 0)
     assert ftarg['pts_per_dec'] == -1
     assert_allclose(f[:9], f1)
@@ -650,17 +659,20 @@ def test_check_time(capsys):
 
     # Assert it can be called repetitively
     _, _ = capsys.readouterr()
-    _, _, _, ftarg = utils.check_time(time, 0, 'dlf', {}, 1)
-    _, _, _, _ = utils.check_time(time, 0, 'dlf', ftarg, 1)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(time, 0, 'dlf', {}, 1)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, _ = utils.check_time(time, 0, 'dlf', ftarg, 1)
     out, _ = capsys.readouterr()
     assert out == ""
 
     # # QWE # #
     # verbose
-    _, f, ft, ftarg = utils.check_time(time, 0, 'qwe', {}, 4)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, f, ft, ftarg = utils.check_time(time, 0, 'qwe', {}, 4)
     out, _ = capsys.readouterr()
     outstr = "   Fourier         :  Quadrature-with-Extrapolation\n     > rtol"
-    assert out[24:87] == outstr
+    assert out[48:111] == outstr
     assert ft == 'qwe'
     assert ftarg['rtol'] == 1e-8
     assert ftarg['atol'] == 1e-20
@@ -683,7 +695,8 @@ def test_check_time(capsys):
     assert ftarg['sincos'] is np.sin
 
     # only limit
-    _, _, _, ftarg = utils.check_time(time, 1, 'qwe', {'limit': 30}, 0)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(time, 1, 'qwe', {'limit': 30}, 0)
     assert ftarg['rtol'] == 1e-8
     assert ftarg['atol'] == 1e-20
     assert ftarg['nquad'] == 21
@@ -696,7 +709,8 @@ def test_check_time(capsys):
     assert ftarg['sincos'] is np.sin
 
     # all arguments
-    _, _, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(
             time, -1, 'qwe',
             {'rtol': 1e-3, 'atol': 1e-4, 'nquad': 31, 'maxint': 20,
              'pts_per_dec': 30, 'diff_quad': 200, 'a': 0.01, 'b': 0.2,
@@ -719,14 +733,17 @@ def test_check_time(capsys):
 
     # Assert it can be called repetitively
     _, _ = capsys.readouterr()
-    _, _, _, ftarg = utils.check_time(time, 0, 'qwe', {}, 1)
-    _, _, _, _ = utils.check_time(time, 0, 'qwe', ftarg, 1)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(time, 0, 'qwe', {}, 1)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, _ = utils.check_time(time, 0, 'qwe', ftarg, 1)
     out, _ = capsys.readouterr()
     assert out == ""
 
     # # FFTLog # #
     # verbose
-    _, f, ft, ftarg = utils.check_time(time, 0, 'fftlog', {}, 4)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, f, ft, ftarg = utils.check_time(time, 0, 'fftlog', {}, 4)
     out, _ = capsys.readouterr()
     outstr = "   Fourier         :  FFTLog\n     > pts_per_dec"
     assert outstr in out
@@ -759,7 +776,8 @@ def test_check_time(capsys):
     assert_allclose(f, fres, rtol=1e-5)
 
     # Several parameters
-    _, _, _, ftarg = utils.check_time(
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(
             time, -1, 'fftlog',
             {'pts_per_dec': 10, 'add_dec': [-3, 4], 'q': 2}, 0)
     assert ftarg['pts_per_dec'] == 10
@@ -772,14 +790,17 @@ def test_check_time(capsys):
 
     # Assert it can be called repetitively
     _, _ = capsys.readouterr()
-    _, _, _, ftarg = utils.check_time(time, 0, 'fftlog', {}, 1)
-    _, _, _, _ = utils.check_time(time, 0, 'fftlog', ftarg, 1)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, ftarg = utils.check_time(time, 0, 'fftlog', {}, 1)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, _, _, _ = utils.check_time(time, 0, 'fftlog', ftarg, 1)
     out, _ = capsys.readouterr()
     assert out == ""
 
     # # FFT # #
     # verbose
-    _, f, ft, ftarg = utils.check_time(time, 0, 'fft', {}, 4)
+    with pytest.warns(DeprecationWarning, match='in v3.0.'):
+        _, f, ft, ftarg = utils.check_time(time, 0, 'fft', {}, 4)
     out, _ = capsys.readouterr()
     assert "Fourier         :  Fast Fourier Transform FFT\n     > dfreq" in out
     assert "     > pts_per_dec :  (linear)" in out
@@ -794,14 +815,15 @@ def test_check_time(capsys):
     assert_allclose(f[-5:], fres[-5:])
 
     # Several parameters
-    _, _, _, ftarg = utils.check_time(
-            time, 0, 'fft', {'dfreq': 1e-3, 'nfreq': 2**15+1, 'ntot': 3}, 0)
+    _, _, _, ftarg, _ = utils.check_time(
+        time, 0, 'fft', {'dfreq': 1e-3, 'nfreq': 2**15+1, 'ntot': 3}, 0, True)
     assert ftarg['dfreq'] == 0.001
     assert ftarg['nfreq'] == 2**15+1
     assert ftarg['ntot'] == 2**16
 
     # Several parameters; pts_per_dec
-    _, f, _, ftarg = utils.check_time(time, 0, 'fft', {'pts_per_dec': 5}, 3)
+    _, f, _, ftarg, _ = utils.check_time(
+        time, 0, 'fft', {'pts_per_dec': 5}, 3, True)
     out, _ = capsys.readouterr()
     assert "     > pts_per_dec :  5" in out
     assert ftarg['dfreq'] == 0.002
@@ -819,8 +841,8 @@ def test_check_time(capsys):
 
     # Assert it can be called repetitively
     _, _ = capsys.readouterr()
-    _, _, _, ftarg = utils.check_time(time, 0, 'fft', {}, 1)
-    _, _, _, _ = utils.check_time(time, 0, 'fft', ftarg, 1)
+    _, _, _, ftarg, _ = utils.check_time(time, 0, 'fft', {}, 1, True)
+    _, _, _, _, _ = utils.check_time(time, 0, 'fft', ftarg, 1, True)
     out, _ = capsys.readouterr()
     assert out == ""
 
@@ -828,26 +850,26 @@ def test_check_time(capsys):
 
     # minimum time
     _ = utils.check_time(
-            0, 0, 'dlf', {'dlf': 'key_201_2012', 'kind': 'cos'}, 1)
+            0, 0, 'dlf', {'dlf': 'key_201_2012', 'kind': 'cos'}, 1, True)
     out, _ = capsys.readouterr()
     assert out[:21] == "* WARNING :: Times < "
 
     # Signal != -1, 0, 1
     with pytest.raises(ValueError, match='<signal> must be one of:'):
-        utils.check_time(time, -2, 'dlf', {}, 0)
+        utils.check_time(time, -2, 'dlf', {}, 0, True)
 
     # ft != cos, sin, dlf, qwe, fftlog,
     with pytest.raises(ValueError, match='<ft> must be one of:'):
-        utils.check_time(time, 0, 'bla', {}, 0)
+        utils.check_time(time, 0, 'bla', {}, 0, True)
 
     # filter missing attributes
     dlf = filters.DigitalFilter('test')
     with pytest.raises(AttributeError, match='DLF-filter is missing some att'):
-        utils.check_time(time, 0, 'dlf', {'dlf': dlf}, 1)
+        utils.check_time(time, 0, 'dlf', {'dlf': dlf}, 1, True)
 
     # filter with wrong kind
     with pytest.raises(ValueError, match="'kind' must be either 'sin' or"):
-        utils.check_time(time, 0, 'dlf', {'kind': 'wrongkind'}, 1)
+        utils.check_time(time, 0, 'dlf', {'kind': 'wrongkind'}, 1, True)
 
 
 def test_check_solution(capsys):


### PR DESCRIPTION
# Add arbitrary waveforms

This PR implements (finally) the possibility for an arbitrary waveform. This will make TEM modelling much easier; addresses #7, #64, and #232.

- [x] Convert all loop examples
  - [x] [TEMFAST](https://empymod--253.org.readthedocs.build/en/253/gallery/tdomain/tem_temfast.html)
  - [x] [WalkTEM](https://empymod--253.org.readthedocs.build/en/253/gallery/tdomain/tem_walktem.html)
    - Delay necessary? Yes, but can be added to times.
    - Bandpass filter necessary? Yes, within bipole.
  - [x] [IP and VRM](https://empymod--253.org.readthedocs.build/en/253/gallery/tdomain/ip_vrm.html)
    - Check B; dB/dt stuff? 'b' returns dB/dt; all good.
    - Negative waveform times? Works
  - [x] Ping folks of relevant examples for feedback
  - [x] Compare waveform to `signal={-1, 0, 1}`
- [x] Add possibility for bandpass filters
- [x] Create a comprehensive loop example or manual entry (see info in #232)
  - [x] bandpass, waveform (?)
- [x] Document & clean up
  - [x] `model.py`
  - [x] `utils.py`
- [x] Add tests
  - [x] `model.py`
  - [x] `utils.py` 
  - [x] Test also against step-on, step-off, impulse (https://github.com/emsig/empymod/issues/232#issuecomment-3807642622) 
- [x] Changelog etc

Other examples that deal in one way or another with loops:
- [Figures 4.7 and 4.8 from Ward and Hohmann](https://empymod.emsig.xyz/en/stable/gallery/reproducing/ward1988.html#ward-and-hohmann-1988-fig-4-7)
- [In-phase and Quadrature, with GEM-2 and DUALEM-842 examples](https://empymod.emsig.xyz/en/latest/gallery/fdomain/ipandq.html)
- [Difference between magnetic dipole and loop sources](https://empymod.emsig.xyz/en/stable/gallery/educational/dipoles_and_loops.html)